### PR TITLE
CI - Workaround for invalid sphinx theme wheel

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -175,6 +175,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip poetry tox
+          poetry config installer.modern-installation false
       - name: Generate the documentation with tox
         run: tox -e doc
 


### PR DESCRIPTION
This PR implements the fix for sphinx-theme-builder's invalid wheel generation. Poetry refuses to install this with 1.4, this is a temporary fix until they make a new release.