### PR TITLE
Provide library name and namespace

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -68,8 +68,8 @@ jobs:
       - name: Build wheelhouse and perform smoke test
         uses: ansys/actions/build-wheelhouse@v4
         with:
-          library-name: ${{ env.PACKAGE_NAME }}
-          library-namespace: ${{ env.PACKAGE_NAMESPACE }}
+          library-name: "ansys-materials-manager"
+          library-namespace: "ansys.materials.manager"
           operating-system: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Apparently build-wheelhouse was broken for a while, but it's only just started failing the step. It looks like we need to provide the library name and namespace to get actions/build-wheelhouse to work, and we hadn't set the env variables properly.