### PR TITLE
Update python shield in README to 3.10 or newer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ PyMaterials Manager
    :target: https://docs.pyansys.com/
    :alt: PyAnsys
 
-.. |python| image:: https://img.shields.io/badge/Python-%3E%3D3.10-blue
+.. |python| image:: https://img.shields.io/pypi/pyversions/ansys-materials-manager
    :target: https://pypi.org/project/pymaterials-manager/
    :alt: Python
 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ PyMaterials Manager
    :alt: PyAnsys
 
 .. |python| image:: https://img.shields.io/pypi/pyversions/ansys-materials-manager
-   :target: https://pypi.org/project/pymaterials-manager/
+   :target: https://pypi.org/project/ansys-materials-manager/
    :alt: Python
 
 .. |pypi| image:: https://img.shields.io/pypi/v/ansys-materials-manager.svg?logo=python&logoColor=white

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ PyMaterials Manager
    :target: https://docs.pyansys.com/
    :alt: PyAnsys
 
-.. |python| image:: https://img.shields.io/badge/Python-%3E%3D3.9-blue
+.. |python| image:: https://img.shields.io/badge/Python-%3E%3D3.10-blue
    :target: https://pypi.org/project/pymaterials-manager/
    :alt: Python
 


### PR DESCRIPTION
README shield currently lists 3.9 and greater as supported, but we do not support 3.9 any more