### PR TITLE
CI - Fix artifact upload name

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -201,6 +201,7 @@ jobs:
         with:
           path: dist/
           retention-days: 7
+          name: ${{ env.PACKAGE_NAME }}-artifacts
 
   upload_dev_docs:
     name: Upload dev documentation


### PR DESCRIPTION
The publish action expects a specific name for the artifact, set that when we upload the built wheel