### PR TITLE
Add isotropic hardening support

### DIFF
--- a/src/ansys/materials/manager/_models/_material_models/isotropic_hardening.py
+++ b/src/ansys/materials/manager/_models/_material_models/isotropic_hardening.py
@@ -20,7 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from ast import Dict
 from typing import Literal
 
 from ansys.units import Quantity
@@ -46,7 +45,7 @@ class IsotropicHardening(MaterialModel):
     )
 
     @model_validator(mode="before")
-    def _initialize_qualifiers(cls, values) -> Dict:
+    def _initialize_qualifiers(cls, values) -> dict:
         expected_qualifiers = {"Definition": ["Multilinear", QualifierType.STRICT]}
         values["model_qualifiers"] = validate_and_initialize_model_qualifiers(
             values, expected_qualifiers

--- a/src/ansys/materials/manager/parsers/rest/_rest_model_map.py
+++ b/src/ansys/materials/manager/parsers/rest/_rest_model_map.py
@@ -19,7 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
+from ansys.materials.manager._models._common import TabularQuantity
 from ansys.materials.manager._models._material_models.cofficient_of_thermal_expansion_isotropic import (  # noqa: E501
     CoefficientofThermalExpansionIsotropic,
 )
@@ -33,6 +33,7 @@ from ansys.materials.manager._models._material_models.elasticity_isotropic impor
 from ansys.materials.manager._models._material_models.electrical_resistivity_isotropic import (
     ElectricalResistivityIsotropic,
 )
+from ansys.materials.manager._models._material_models.isotropic_hardening import IsotropicHardening
 from ansys.materials.manager._models._material_models.specific_heat import SpecificHeat
 from ansys.materials.manager._models._material_models.tensile_elongation import TensileElongation
 from ansys.materials.manager._models._material_models.tensile_strength import (
@@ -92,33 +93,92 @@ MATERIAL_MODEL_MAP[CoefficientofThermalExpansionIsotropic] = ModelInfo(
     attributes=["coefficient_of_thermal_expansion"],
 )
 
-# ---------------------------------------------------------------------------
-# Tabular (temperature-dependent) model variants
-# ---------------------------------------------------------------------------
-# These share the same MaterialModel class as their scalar counterparts but
-# require a method_read that parses the "columns" array format.  They are
-# registered in MODEL_ID_INFO_MAP so the per-ID ModelInfo takes precedence
-# over MATERIAL_MODEL_MAP during reading.
+MODEL_ID_MAP["tensile.strength.ultimate"] = TensileStrengthUltimate
+MATERIAL_MODEL_MAP[TensileStrengthUltimate] = ModelInfo(
+    labels=["Tensile strength, ultimate"],
+    attributes=["tensile_strength_ultimate"],
+)
+
+MODEL_ID_MAP["tensile.strength.yield"] = TensileStrengthYield
+MATERIAL_MODEL_MAP[TensileStrengthYield] = ModelInfo(
+    labels=["Tensile strength, yield"],
+    attributes=["tensile_strength_yield"],
+)
+
+MODEL_ID_MAP["compressive.strength.ultimate"] = CompressiveStrengthUltimate
+MATERIAL_MODEL_MAP[CompressiveStrengthUltimate] = ModelInfo(
+    labels=["Compressive strength, ultimate"],
+    attributes=["compressive_strength_ultimate"],
+)
+
+MODEL_ID_MAP["tensile.elongation"] = TensileElongation
+MATERIAL_MODEL_MAP[TensileElongation] = ModelInfo(
+    labels=["Tensile elongation"],
+    attributes=["tensile_elongation"],
+)
+
+MODEL_ID_MAP["electrical.resistivity"] = ElectricalResistivityIsotropic
+MATERIAL_MODEL_MAP[ElectricalResistivityIsotropic] = ModelInfo(
+    labels=["Electrical resistivity"],
+    attributes=["electrical_resistivity"],
+)
 
 
-def _tabular_reader(*attr_label_pairs: tuple[str, str]):
-    """Create a tabular model reader from one or more ``(attribute, label)`` pairs.
+def _tabular_reader(*attr_label_pairs: tuple[str, str], ip_rename: dict[str, str] | None = None):
+    """
+    Create a tabular model reader from one or more ``(attribute, label)`` pairs.
+
+    Optionally renames independent parameters if a mapping dict is provided via
+    the ``ip_rename`` parameter.
 
     Parameters
     ----------
     *attr_label_pairs : tuple[str, str]
         Each pair maps a model attribute name to its Granta MI property label.
+    ip_rename : dict[str, str] | None, optional
+        Optional mapping of ``{old_ip_name: new_ip_name}``. When provided, any
+        :class:`~.IndependentParameter` whose name matches a key is renamed before
+        the :class:`~.TabularQuantity` is returned.
 
     Returns
     -------
     Callable
         A reader function compatible with :class:`~ModelInfo`'s ``method_read``.
     """
+
+    def _rename(tabular_quantity: TabularQuantity | None) -> TabularQuantity | None:
+        """Rename matching independent parameters in the tabular quantity."""
+        if tabular_quantity is None or ip_rename is None:
+            return tabular_quantity
+        renamed_ips = [
+            ip.model_copy(update={"name": ip_rename.get(ip.name, ip.name)})
+            for ip in tabular_quantity.independent_parameters
+        ]
+        return tabular_quantity.model_copy(update={"independent_parameters": renamed_ips})
+
     attributes = tuple(a for a, _ in attr_label_pairs)
     labels = tuple(label for _, label in attr_label_pairs)
 
     def _read(model_data: dict):
-        return (attributes, tuple(get_tabular_property(model_data, label) for label in labels))
+        """
+        Extract tabular properties from a single model section.
+
+        Renames independent parameters if required.
+
+        Parameters
+        ----------
+        model_data : dict
+            Material model in Granta MI format.
+
+        Returns
+        -------
+        tuple[tuple[str, ...], tuple[TabularQuantity | None, ...]]
+            Parallel sequences of attributes and tabular quantities.
+        """
+        tabular_quantities = tuple(
+            _rename(get_tabular_property(model_data, label)) for label in labels
+        )
+        return attributes, tabular_quantities
 
     return _read
 
@@ -146,17 +206,6 @@ MODEL_ID_INFO_MAP["tensile.strength.yield.with.temp"] = ModelInfo(
     method_read=_tabular_reader(("tensile_strength_yield", "Tensile strength, yield"))
 )
 
-MODEL_ID_MAP["tensile.strength.ultimate"] = TensileStrengthUltimate
-MATERIAL_MODEL_MAP[TensileStrengthUltimate] = ModelInfo(
-    labels=["Tensile strength, ultimate"],
-    attributes=["tensile_strength_ultimate"],
-)
-
-MODEL_ID_MAP["tensile.strength.yield"] = TensileStrengthYield
-MATERIAL_MODEL_MAP[TensileStrengthYield] = ModelInfo(
-    labels=["Tensile strength, yield"],
-    attributes=["tensile_strength_yield"],
-)
 
 MODEL_ID_MAP["specific.heat.capacity.with.temp"] = SpecificHeat
 MODEL_ID_INFO_MAP["specific.heat.capacity.with.temp"] = ModelInfo(
@@ -175,22 +224,9 @@ MODEL_ID_INFO_MAP["thermal.expansion.coefficient.with.temp"] = ModelInfo(
     )
 )
 
-
-MODEL_ID_MAP["compressive.strength.ultimate"] = CompressiveStrengthUltimate
-MATERIAL_MODEL_MAP[CompressiveStrengthUltimate] = ModelInfo(
-    labels=["Compressive strength, ultimate"],
-    attributes=["compressive_strength_ultimate"],
-)
-
 MODEL_ID_MAP["compressive.strength.ultimate.with.temp"] = CompressiveStrengthUltimate
 MODEL_ID_INFO_MAP["compressive.strength.ultimate.with.temp"] = ModelInfo(
     method_read=_tabular_reader(("compressive_strength_ultimate", "Compressive strength, ultimate"))
-)
-
-MODEL_ID_MAP["tensile.elongation"] = TensileElongation
-MATERIAL_MODEL_MAP[TensileElongation] = ModelInfo(
-    labels=["Tensile elongation"],
-    attributes=["tensile_elongation"],
 )
 
 MODEL_ID_MAP["tensile.elongation.with.temp"] = TensileElongation
@@ -198,13 +234,44 @@ MODEL_ID_INFO_MAP["tensile.elongation.with.temp"] = ModelInfo(
     method_read=_tabular_reader(("tensile_elongation", "Tensile elongation"))
 )
 
-MODEL_ID_MAP["electrical.resistivity"] = ElectricalResistivityIsotropic
-MATERIAL_MODEL_MAP[ElectricalResistivityIsotropic] = ModelInfo(
-    labels=["Electrical resistivity"],
-    attributes=["electrical_resistivity"],
-)
-
 MODEL_ID_MAP["electrical.resistivity.with.temp"] = ElectricalResistivityIsotropic
 MODEL_ID_INFO_MAP["electrical.resistivity.with.temp"] = ModelInfo(
     method_read=_tabular_reader(("electrical_resistivity", "Electrical resistivity"))
 )
+
+
+def _multilinear_hardening_reader(model_data: dict):
+    """
+    Read a ``multilinear.hardening`` model section into :class:`~.IsotropicHardening` fields.
+
+    This reader uses :func:`_tabular_reader` to parse and rename the 'Strain' independent
+    parameter to 'Plastic Strain', then unpacks the intermediate :class:`~.TabularQuantity`
+    into the ``(stress, independent_parameters)`` shape the model expects.
+
+    Parameters
+    ----------
+    model_data : dict
+        A model section dict from the REST response (``modelId == "multilinear.hardening"``).
+
+    Returns
+    -------
+    tuple[tuple[str, ...], tuple]
+        ``(attribute_names, values)`` compatible with :class:`~.ModelInfo`'s ``method_read``
+        contract.  Attribute names are ``("stress", "independent_parameters")``.
+
+    Notes
+    -----
+    This function returns the values directly, as opposed to the underlying ``_tabular_reader()``
+    which returns a function which returns the values.
+    """
+    _reader = _tabular_reader(
+        ("stress", "True stress with strain"), ip_rename={"Strain": "Plastic Strain"}
+    )
+    _, (tq,) = _reader(model_data)
+    if tq is None:
+        return (("stress", "independent_parameters"), (None, []))
+    return (("stress", "independent_parameters"), (tq.values, tq.independent_parameters))
+
+
+MODEL_ID_MAP["multilinear.hardening"] = IsotropicHardening
+MODEL_ID_INFO_MAP["multilinear.hardening"] = ModelInfo(method_read=_multilinear_hardening_reader)

--- a/src/ansys/materials/manager/parsers/rest/_rest_model_map.py
+++ b/src/ansys/materials/manager/parsers/rest/_rest_model_map.py
@@ -267,7 +267,8 @@ def _multilinear_hardening_reader(model_data: dict):
     which returns a function which returns the values.
     """
     _reader = _tabular_reader(
-        ("stress", "True stress with strain"), ip_rename={"Strain": "Plastic Strain"}
+        ("stress", "True stress with strain"),
+        independent_parameter_map={"Strain": "Plastic Strain"},
     )
     _, (tq,) = _reader(model_data)
     if tq is None:

--- a/src/ansys/materials/manager/parsers/rest/_rest_model_map.py
+++ b/src/ansys/materials/manager/parsers/rest/_rest_model_map.py
@@ -124,7 +124,9 @@ MATERIAL_MODEL_MAP[ElectricalResistivityIsotropic] = ModelInfo(
 )
 
 
-def _tabular_reader(*attr_label_pairs: tuple[str, str], ip_rename: dict[str, str] | None = None):
+def _tabular_reader(
+    *attr_label_pairs: tuple[str, str], independent_parameter_map: dict[str, str] | None = None
+):
     """
     Create a tabular model reader from one or more ``(attribute, label)`` pairs.
 
@@ -135,7 +137,7 @@ def _tabular_reader(*attr_label_pairs: tuple[str, str], ip_rename: dict[str, str
     ----------
     *attr_label_pairs : tuple[str, str]
         Each pair maps a model attribute name to its Granta MI property label.
-    ip_rename : dict[str, str] | None, optional
+    independent_parameter_map : dict[str, str] | None, optional
         Optional mapping of ``{old_ip_name: new_ip_name}``. When provided, any
         :class:`~.IndependentParameter` whose name matches a key is renamed before
         the :class:`~.TabularQuantity` is returned.
@@ -148,10 +150,10 @@ def _tabular_reader(*attr_label_pairs: tuple[str, str], ip_rename: dict[str, str
 
     def _rename(tabular_quantity: TabularQuantity | None) -> TabularQuantity | None:
         """Rename matching independent parameters in the tabular quantity."""
-        if tabular_quantity is None or ip_rename is None:
+        if tabular_quantity is None or independent_parameter_map is None:
             return tabular_quantity
         renamed_ips = [
-            ip.model_copy(update={"name": ip_rename.get(ip.name, ip.name)})
+            ip.model_copy(update={"name": independent_parameter_map.get(ip.name, ip.name)})
             for ip in tabular_quantity.independent_parameters
         ]
         return tabular_quantity.model_copy(update={"independent_parameters": renamed_ips})

--- a/tests/rest/common.py
+++ b/tests/rest/common.py
@@ -85,5 +85,22 @@ def _tabular_section(model_id, prop_name, dep_unit, dep_values, temps=None):
     }
 
 
+def multilinear_hardening_section(strains, stresses):
+    """Return a model section dict for Multilinear hardening matching the Granta MI REST schema."""
+    return {
+        "modelId": "multilinear.hardening",
+        "constraints": [],
+        "properties": [
+            {
+                "name": "True stress with strain",
+                "columns": [
+                    _col("Stress", "Pa", stresses, False),
+                    _col("Strain", "strain", strains, True),
+                ],
+            }
+        ],
+    }
+
+
 def tabular_density_section(temps, densities):
     return _tabular_section("density.with.temp", "Density", "kg/m^3", densities, temps)

--- a/tests/rest/static_test_data.py
+++ b/tests/rest/static_test_data.py
@@ -447,7 +447,35 @@ BROAD_COVERAGE_PAYLOAD = {
                     {
                         "modelId": "multilinear.hardening",
                         "constraints": [],
-                        "properties": []
+                        "properties": [
+                            {
+                                "name": "True stress with strain",
+                                "columns": [
+                                    {
+                                        "name": "Stress",
+                                        "isFreeParameter": false,
+                                        "numericValues": [
+                                            204267400.0,
+                                            215867000.0,
+                                            227161500.0,
+                                            238158400.0
+                                        ],
+                                        "unit": "Pa"
+                                    },
+                                    {
+                                        "name": "Strain",
+                                        "isFreeParameter": true,
+                                        "numericValues": [
+                                            0.0,
+                                            0.002,
+                                            0.004,
+                                            0.006
+                                        ],
+                                        "unit": "strain"
+                                    }
+                                ]
+                            }
+                        ]
                     },
                     {
                         "modelId": "specific.heat.capacity",

--- a/tests/rest/test_rest_tabular.py
+++ b/tests/rest/test_rest_tabular.py
@@ -473,10 +473,11 @@ class TestMultilinearHardening:
     def section(self):
         return multilinear_hardening_section(self._STRAINS, self._STRESSES)
 
-    def test_tabular_reader_ip_rename(self, section):
-        """ip_rename should rename IPs in the returned TabularQuantity."""
+    def test_tabular_reader_independent_parameter_map(self, section):
+        """independent_parameter_map should rename IPs in the returned TabularQuantity."""
         reader = _tabular_reader(
-            ("stress", "True stress with strain"), ip_rename={"Strain": "Plastic Strain"}
+            ("stress", "True stress with strain"),
+            independent_parameter_map={"Strain": "Plastic Strain"},
         )
         attrs, values = reader(section)
         tq = dict(zip(attrs, values))[
@@ -485,8 +486,8 @@ class TestMultilinearHardening:
         assert isinstance(tq, TabularQuantity)
         assert tq.independent_parameters[0].name == "Plastic Strain"
 
-    def test_tabular_reader_ip_rename_not_provided_preserves_name(self, section):
-        """Without ip_rename the original column name should be preserved."""
+    def test_tabular_reader_independent_parameter_map_not_provided_preserves_name(self, section):
+        """Without independent_parameter_map the original column name should be preserved."""
         reader = _tabular_reader(("stress", "True stress with strain"))
         attrs, values = reader(section)
         tq = dict(zip(attrs, values))["stress"]

--- a/tests/rest/test_rest_tabular.py
+++ b/tests/rest/test_rest_tabular.py
@@ -20,10 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from ansys.units import Quantity
 import pytest
 
 from ansys.materials.manager._models._common.tabular_quantity import TabularQuantity
 from ansys.materials.manager._models._material_models.density import Density
+from ansys.materials.manager._models._material_models.isotropic_hardening import IsotropicHardening
 from ansys.materials.manager._models._material_models.tensile_strength import (
     TensileStrengthUltimate,
     TensileStrengthYield,
@@ -41,8 +43,12 @@ from ansys.materials.manager.parsers.rest._rest_reader import (
 )
 from ansys.materials.manager.parsers.rest.rest_material_reader import RestMaterialReader
 
-from .common import minimal_json, tabular_density_section
-from .static_test_data import TABULAR_ELASTICITY_WITH_TEMPERATURE_MODEL
+from .common import (
+    minimal_json,
+    multilinear_hardening_section,
+    tabular_density_section,
+)
+from .static_test_data import BROAD_COVERAGE_PAYLOAD, TABULAR_ELASTICITY_WITH_TEMPERATURE_MODEL
 
 
 class TestTabularReader:
@@ -455,3 +461,77 @@ class TestDimensionalityPreference:
         assert any(
             "unit" in r.message.lower() for r in caplog.records if r.levelno == logging.WARNING
         )
+
+
+class TestMultilinearHardening:
+    """Tests for the multilinear.hardening → IsotropicHardening mapping."""
+
+    _STRAINS = [0.0, 0.002, 0.004, 0.006]
+    _STRESSES = [204267400.0, 215867000.0, 227161500.0, 238158400.0]
+
+    @pytest.fixture
+    def section(self):
+        return multilinear_hardening_section(self._STRAINS, self._STRESSES)
+
+    def test_tabular_reader_ip_rename(self, section):
+        """ip_rename should rename IPs in the returned TabularQuantity."""
+        reader = _tabular_reader(
+            ("stress", "True stress with strain"), ip_rename={"Strain": "Plastic Strain"}
+        )
+        attrs, values = reader(section)
+        tq = dict(zip(attrs, values))[
+            "stress"
+        ]  # Mirrors how attributes and values are mapped when creating models
+        assert isinstance(tq, TabularQuantity)
+        assert tq.independent_parameters[0].name == "Plastic Strain"
+
+    def test_tabular_reader_ip_rename_not_provided_preserves_name(self, section):
+        """Without ip_rename the original column name should be preserved."""
+        reader = _tabular_reader(("stress", "True stress with strain"))
+        attrs, values = reader(section)
+        tq = dict(zip(attrs, values))["stress"]
+        assert tq.independent_parameters[0].name == "Strain"
+
+    @pytest.fixture
+    def model(self, section):
+        raw = minimal_json(models=[section])
+        result = RestMaterialReader(raw).convert_materials()
+        return result["Steel"].get_model_by_name("Isotropic Hardening")
+
+    def test_model_is_populated(self, model):
+        """The IsotropicHardening model should be present in the material."""
+        assert model is not None
+        assert isinstance(model, IsotropicHardening)
+
+    def test_stress_is_quantity(self, model):
+        """model.stress should be a plain Quantity, not a TabularQuantity."""
+        assert isinstance(model.stress, Quantity)
+        assert not isinstance(model.stress, TabularQuantity)
+
+    def test_stress_values(self, model):
+        """Stress values should match the payload."""
+        assert list(model.stress.value) == pytest.approx(self._STRESSES)
+
+    def test_stress_unit(self, model):
+        """Stress unit should be Pa."""
+        assert model.stress.unit == "Pa"
+
+    def test_plastic_strain_ip_present(self, model):
+        """independent_parameters should contain exactly one IP named 'Plastic Strain'."""
+        ip_names = [ip.name for ip in model.independent_parameters]
+        assert ip_names == ["Plastic Strain"]
+
+    def test_plastic_strain_values(self, model):
+        """Plastic strain values should match the payload."""
+        ip = model.independent_parameters[0]
+        assert list(ip.values.value) == pytest.approx(self._STRAINS)
+
+    def test_broad_coverage_payload_includes_hardening(self):
+        """BROAD_COVERAGE_PAYLOAD should produce an IsotropicHardening model."""
+        result = RestMaterialReader(BROAD_COVERAGE_PAYLOAD).convert_materials()
+        material = result.get("Synthetic Carbon Steel")
+        assert material is not None
+        model = material.get_model_by_name("Isotropic Hardening")
+        assert model is not None
+        assert isinstance(model, IsotropicHardening)
+        assert isinstance(model.stress, Quantity)


### PR DESCRIPTION
Bases #528 

Closes #536 

Adds support for the isotropic hardening model. Builds on the work to support temperature-dependency, but requires some abstraction because the 'Strain' parameter has to be mapped to the 'Plastic Strain' independent parameter.

Everything else is just refactoring, mapping, and tests.