### PR TITLE
Implement writer visitor pattern for model serialization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,11 @@ PyMaterials Manager.
 
 The following contribution information is specific to PyMaterials Manager.
 
+For the writer visitor pattern, adding new material models, and wiring models to
+solvers (MAPDL, MatML, Fluent, LS-DYNA), see the
+[Developer guide](doc/source/developer_guide.rst) in the Sphinx documentation
+(built locally with ``uv run --group doc sphinx-build -b html doc/source doc/build``).
+
 [Contributing]: https://dev.docs.pyansys.com/how-to/contributing.html
 
 <!-- Begin content specific to your library here. -->

--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -27,3 +27,11 @@ Vocab = ANSYS
 # Apply the following styles
 BasedOnStyles = Vale, Google
 Vale.Terms = NO
+
+# Google.Spacing false-positives on dotted Sphinx API paths (for example
+# ansys.materials.manager.models.Material). TokenIgnores covers most inline
+# roles; disable the rule for any remaining abbreviation noise in technical docs.
+Google.Spacing = NO
+
+# Ignore Sphinx inline roles (for example :class:, :meth:, :mod:) and HTML tags.
+TokenIgnores = (:.*:`.*`)|(<.*>)

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -11,6 +11,9 @@ with this guide before attempting to contribute to PyMaterials Manager.
  
 The following contribution information is specific to PyMaterials Manager.
 
+For architecture and extension workflows (visitor pattern, new models, new solver
+maps), see :ref:`ref_developer_guide`.
+
 
 Clone the repository and install the package
 ============================================

--- a/doc/source/developer_guide.rst
+++ b/doc/source/developer_guide.rst
@@ -1,0 +1,240 @@
+.. _ref_developer_guide:
+
+===============
+Developer guide
+===============
+
+This page describes how material **writers** serialize domain models using the
+`visitor pattern <https://en.wikipedia.org/wiki/Visitor_pattern>`_, and how to
+extend the library with new models or solver integrations.
+
+End users typically interact with :class:`~ansys.materials.manager.MaterialManager`
+and do not need to know about visitors. Contributors and anyone subclassing
+writers should read this guide.
+
+
+Writer visitor pattern
+======================
+
+Problem
+-------
+
+Material models (for example :class:`~ansys.materials.manager.models.Density`,
+:class:`~ansys.materials.manager.models.ElasticityIsotropic`) are
+solver-agnostic Pydantic objects in :mod:`ansys.materials.manager.models`.
+Writers in :mod:`ansys.materials.manager.integrations` must turn those objects
+into MatML XML, MAPDL command strings, Fluent dictionaries, or LS-DYNA keyword
+cards **without** importing solver logic into the model layer.
+
+Solution: double dispatch
+-------------------------
+
+Traversal uses **double dispatch**. The model does not know which solver is
+targeted; the writer does not use long ``isinstance`` chains to pick behavior.
+
+1. A writer is constructed with a list of :class:`~ansys.materials.manager.models.Material`
+   instances.
+2. The writer calls :meth:`~ansys.materials.manager.models.Material.accept`.
+3. Each :class:`~ansys.materials.manager.models.MaterialModel` on that material
+   calls :meth:`~ansys.materials.manager.models.MaterialModel.accept`, which
+   delegates to ``visitor.visit(self, material_name=...)``.
+4. The writer's ``visit`` implementation (usually
+   ``@functools.singledispatchmethod``) selects the handler for the concrete
+   model type.
+5. Output fragments accumulate in ``writer._material_repr[material_name]`` until
+   ``write()`` serializes them.
+
+.. code-block:: text
+
+   MaterialManager.write_to_mapdl(...)
+        └── MapdlWriter(materials)
+                 └── material.accept(writer)
+                          └── model.accept(writer, material_name=...)
+                                   └── writer.visit(model, material_name=...)
+                                            └── @visit.register handler
+
+Key types
+---------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Type
+     - Location
+     - Role
+   * - :class:`~ansys.materials.manager.integrations.MaterialModelWriterVisitor`
+     - ``integrations``
+     - Abstract visitor protocol (``visit``, ``visit_material``, ``is_supported``)
+   * - :class:`~ansys.materials.manager.integrations.BaseVisitor`
+     - ``integrations``
+     - Shared writer base: ``_model_map``, ``_populate_dependent_parameters``, traversal
+   * - :class:`~ansys.materials.manager.integrations._common.ModelInfo`
+     - ``integrations._common``
+     - Declarative map from model fields to external labels (or ``method_write``)
+   * - Concrete writers
+     - ``integrations.matml``, ``mapdl``, ``fluent``, ``lsdyna``
+     - Format-specific ``visit`` handlers and ``write()``
+
+Import boundary
+---------------
+
+- ``integrations`` imports ``models``.
+- ``models`` **never** imports ``integrations``. ``MaterialModel.accept`` only
+  references a typing :class:`~ansys.materials.manager.models._common.visitor_protocol.MaterialModelWriterVisitor`
+  protocol.
+
+Each writer class defines its **own** ``@singledispatchmethod visit`` so handler
+registries are not shared across MatML, MAPDL, Fluent, and LS-DYNA.
+
+
+``ModelInfo`` maps vs custom ``visit`` handlers
+================================================
+
+Most models only need a row in the writer's ``_*_model_map.py`` file:
+
+.. code-block:: python
+
+   MyModel: ModelInfo(
+       labels=["EXTERNAL_LABEL"],
+       attributes=["python_field_name"],
+   ),
+
+The default ``visit`` handler calls
+:meth:`~ansys.materials.manager.integrations.BaseVisitor._populate_dependent_parameters`,
+which reads ``_model_map``.
+
+When labels and fields do not map 1:1, use ``method_write``:
+
+.. code-block:: python
+
+   MyModel: ModelInfo(method_write=map_from_my_model),
+
+Define ``map_from_my_model(model) -> (labels, quantities)`` in the same module
+(see existing MAPDL mappers in ``integrations/mapdl/_mapdl_model_map.py``).
+
+When the entire output format is bespoke (MAPDL TB tables, multi-line APDL),
+register a typed handler on that writer's ``visit``:
+
+.. code-block:: python
+
+   class MapdlWriter(BaseVisitor):
+       @singledispatchmethod
+       def visit(self, model: MaterialModel, *, material_name: str) -> None:
+           ...
+
+       @visit.register(MyModel)
+       def _visit_my_model(self, model: MyModel, *, material_name: str) -> None:
+           output = self._write_my_model_special(model)
+           self._material_repr[material_name].append(output)
+
+Only a small number of MAPDL models need this; the rest use the shared
+"standard constants / tables" path via the default ``MaterialModel`` handler.
+
+
+Readers are not visitors
+========================
+
+MatML and REST **readers** build :class:`~ansys.materials.manager.models.MaterialModel`
+instances from external data. They use the same :class:`~ansys.materials.manager.integrations._common.ModelInfo`
+maps (with ``method_read`` where needed) but **do not** call ``accept()``.
+Dispatch is keyed by XML property names or Granta MI model IDs, not by existing
+model instances.
+
+
+Adding a new material model
+===========================
+
+Use this checklist when introducing a new domain concept (a new
+:class:`~ansys.materials.manager.models.MaterialModel` subclass).
+
+1. **Define the model** in ``src/ansys/materials/manager/models/_material_models/``.
+
+   - Subclass :class:`~ansys.materials.manager.models.MaterialModel`.
+   - Set a frozen ``name: Literal["..."]``, fields, and ``supported_packages``.
+   - Do **not** override ``accept()``; it is inherited from the base class.
+
+2. **Export** the class from ``models/_material_models/__init__.py`` (and thus
+   ``models.__all__``).
+
+3. **MatML (canonical interchange)** — add an entry to
+   ``integrations/matml/_matml_model_map.py``. One entry covers MatML read and write.
+
+4. **REST / Granta MI** (if applicable) — add ``MODEL_ID_MAP`` and
+   ``MATERIAL_MODEL_MAP`` entries in ``integrations/rest/_rest_model_map.py``.
+
+5. **Per-solver writer maps** — see :ref:`ref_add_solver_support` for each target
+   (MAPDL, Fluent, LS-DYNA).
+
+6. **Tests** — golden-file tests under ``tests/matml/``, ``tests/mapdl/``, etc.
+   Add a ``minimal_model_factory`` entry in ``tests/integrations/conftest.py`` so
+   map-coverage smoke tests pick up the new type (optional but recommended).
+
+
+.. _ref_add_solver_support:
+
+Adding solver support for an existing model
+===========================================
+
+For each solver, edit **one map file** unless the model needs custom MAPDL
+serialization or LS-DYNA card composition.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Solver
+     - Map file
+     - Extra steps
+   * - MatML
+     - ``integrations/matml/_matml_model_map.py``
+     - Usually already present if the model exists
+   * - MAPDL
+     - ``integrations/mapdl/_mapdl_model_map.py``
+     - ``@visit.register`` only for non-standard output (see
+       :class:`~ansys.materials.manager.integrations.mapdl.MapdlWriter`)
+   * - Fluent
+     - ``integrations/fluent/_fluent_model_map.py``
+     - Map entry only
+   * - LS-DYNA
+     - ``integrations/lsdyna/_ls_dyna_model_map.py``
+     - Update ``_get_material_card_map()`` in ``lsdyna_writer.py`` if the model
+       participates in a keyword card
+
+**Simple case** (example: density to MAPDL ``DENS``):
+
+.. code-block:: python
+
+   # integrations/mapdl/_mapdl_model_map.py
+   MyModel: ModelInfo(labels=["DENS"], attributes=["density"]),
+
+After adding the map entry, the writer's default ``visit`` handler serializes the
+model. No changes to ``MapdlWriter`` are required.
+
+**LS-DYNA card composition** — LS-DYNA merges multiple models into one keyword
+card. Ensure each constituent model is in ``_ls_dyna_model_map.py``, then add or
+update an entry in ``_get_material_card_map()`` keyed by the tuple of model
+classes present on a :class:`~ansys.materials.manager.models.Material`.
+
+
+Testing
+=======
+
+Use a **layered** approach:
+
+1. **Visitor mechanics** — ``tests/integrations/test_visitor_dispatch.py`` (fast
+   dispatch and ``accept`` wiring).
+2. **Map coverage** — ``tests/integrations/test_writer_map_coverage.py``
+   (parametrized smoke test per writer map).
+3. **Format golden files** — existing tests under ``tests/matml/``, ``tests/mapdl/``,
+   etc. (prove correct XML / APDL / Fluent / LS-DYNA output).
+
+For a new simple map entry, layers 1–2 plus an optional golden file are usually
+enough. Complex MAPDL or tabular output should always have a golden-file test.
+
+
+Further reading
+===============
+
+- API reference: :class:`~ansys.materials.manager.integrations.MaterialModelWriterVisitor`,
+  :class:`~ansys.materials.manager.integrations.BaseVisitor`, and concrete writers
+  (generated from docstrings).
+- Module overview: :mod:`ansys.materials.manager.integrations`.

--- a/doc/source/developer_guide.rst
+++ b/doc/source/developer_guide.rst
@@ -8,9 +8,9 @@ This page describes how material **writers** serialize domain models using the
 `visitor pattern <https://en.wikipedia.org/wiki/Visitor_pattern>`_, and how to
 extend the library with new models or solver integrations.
 
-End users typically interact with ``MaterialManager`` and do not need to know
-about visitors. Contributors and anyone subclassing writers should read this
-guide.
+End users typically interact with :class:`~ansys.materials.manager.MaterialManager`
+and do not need to know about visitors. Contributors and anyone subclassing
+writers should read this guide.
 
 
 Writer visitor pattern
@@ -19,11 +19,12 @@ Writer visitor pattern
 Problem
 -------
 
-Material models (for example ``Density`` and ``ElasticityIsotropic``) are
-solver-agnostic Pydantic objects in the ``models`` package. Writers in
-``integrations`` must turn those objects into MatML XML, MAPDL command strings,
-Fluent dictionaries, or LS-DYNA keyword cards **without** importing solver
-logic into the model layer.
+Material models (for example :class:`~ansys.materials.manager.models.Density`,
+:class:`~ansys.materials.manager.models.ElasticityIsotropic`) are
+solver-agnostic Pydantic objects in :mod:`ansys.materials.manager.models`.
+Writers in :mod:`ansys.materials.manager.integrations` must turn those objects
+into MatML XML, MAPDL command strings, Fluent dictionaries, or LS-DYNA keyword
+cards **without** importing solver logic into the model layer.
 
 Double dispatch
 ---------------
@@ -31,9 +32,11 @@ Double dispatch
 Traversal uses **double dispatch**. The model does not know which solver is
 targeted; the writer does not use long ``isinstance`` chains to pick behavior.
 
-1. A writer is constructed with a list of ``Material`` instances.
-2. The writer calls ``Material.accept``.
-3. Each ``MaterialModel`` on that material calls ``MaterialModel.accept``, which
+1. A writer is constructed with a list of :class:`~ansys.materials.manager.models.Material`
+   instances.
+2. The writer calls :meth:`~ansys.materials.manager.models.Material.accept`.
+3. Each :class:`~ansys.materials.manager.models.MaterialModel` on that material
+   calls :meth:`~ansys.materials.manager.models.MaterialModel.accept`, which
    delegates to ``visitor.visit(self, material_name=...)``.
 4. The writer's ``visit`` implementation (usually
    ``@functools.singledispatchmethod``) selects the handler for the concrete
@@ -59,16 +62,16 @@ Key types
    * - Type
      - Location
      - Role
-   * - ``MaterialModelWriterVisitor``
+   * - :class:`~ansys.materials.manager.integrations.MaterialModelWriterVisitor`
      - ``integrations``
      - Abstract visitor (``visit``, ``visit_material``, ``is_supported``)
-   * - ``MaterialModelWriterVisitorProtocol``
+   * - :class:`~ansys.materials.manager.models._common.visitor_protocol.MaterialModelWriterVisitorProtocol`
      - ``models._common.visitor_protocol``
      - Structural typing protocol used by ``accept()`` (no integrations import)
-   * - ``BaseVisitor``
+   * - :class:`~ansys.materials.manager.integrations.BaseVisitor`
      - ``integrations``
      - Shared writer base: ``_model_map``, ``_populate_dependent_parameters``, traversal
-   * - ``ModelInfo``
+   * - :class:`~ansys.materials.manager.integrations._common.ModelInfo`
      - ``integrations._common``
      - Declarative map from model fields to external labels (or ``method_write``)
    * - Concrete writers
@@ -80,7 +83,8 @@ Import boundary
 
 - ``integrations`` imports ``models``.
 - ``models`` **never** imports ``integrations``. ``Material.accept`` and
-  ``MaterialModel.accept`` only reference ``MaterialModelWriterVisitorProtocol``.
+  ``MaterialModel.accept`` only reference
+  :class:`~ansys.materials.manager.models._common.visitor_protocol.MaterialModelWriterVisitorProtocol`.
 
 Each writer class defines its **own** ``@singledispatchmethod visit`` so handler
 registries are not shared across MatML, MAPDL, Fluent, and LS-DYNA.
@@ -98,7 +102,8 @@ Most models only need a row in the writer's ``_*_model_map.py`` file:
        attributes=["python_field_name"],
    ),
 
-The default ``visit`` handler calls ``BaseVisitor._populate_dependent_parameters``,
+The default ``visit`` handler calls
+:meth:`~ansys.materials.manager.integrations.BaseVisitor._populate_dependent_parameters`,
 which reads ``_model_map``.
 
 When labels and fields do not map 1:1, use ``method_write``:
@@ -132,21 +137,22 @@ Only a small number of MAPDL models need this; the rest use the shared
 Readers are not visitors
 ========================
 
-MatML and REST **readers** build ``MaterialModel`` instances from external data.
-They use the same ``ModelInfo`` maps (with ``method_read`` where needed) but
-**do not** call ``accept()``. Dispatch is keyed by XML property names or Granta
-MI model IDs, not by existing model instances.
+MatML and REST **readers** build :class:`~ansys.materials.manager.models.MaterialModel`
+instances from external data. They use the same :class:`~ansys.materials.manager.integrations._common.ModelInfo`
+maps (with ``method_read`` where needed) but **do not** call ``accept()``.
+Dispatch is keyed by XML property names or Granta MI model IDs, not by existing
+model instances.
 
 
 Adding a new material model
 ===========================
 
-Use this checklist when introducing a new domain concept (a new ``MaterialModel``
-subclass).
+Use this checklist when introducing a new domain concept (a new
+:class:`~ansys.materials.manager.models.MaterialModel` subclass).
 
 1. **Define the model** in ``src/ansys/materials/manager/models/_material_models/``.
 
-   - Subclass ``MaterialModel``.
+   - Subclass :class:`~ansys.materials.manager.models.MaterialModel`.
    - Set a frozen ``name: Literal["..."]``, fields, and ``supported_packages``.
    - Do **not** override ``accept()``; it is inherited from the base class.
 
@@ -186,7 +192,8 @@ serialization or LS-DYNA card composition.
      - Usually already present if the model exists
    * - MAPDL
      - ``integrations/mapdl/_mapdl_model_map.py``
-     - ``@visit.register`` only for non-standard output (see ``MapdlWriter``)
+     - ``@visit.register`` only for non-standard output (see
+       :class:`~ansys.materials.manager.integrations.mapdl.MapdlWriter`)
    * - Fluent
      - ``integrations/fluent/_fluent_model_map.py``
      - Map entry only
@@ -208,23 +215,25 @@ model. No changes to ``MapdlWriter`` are required.
 **LS-DYNA card composition**: LS-DYNA merges multiple models into one keyword
 card. Ensure each constituent model is in ``_ls_dyna_model_map.py``, then add or
 update an entry in ``_get_material_card_map()`` keyed by the tuple of model
-classes present on a ``Material``.
+classes present on a :class:`~ansys.materials.manager.models.Material`.
 
 
 ``is_supported`` and unsupported models
 =======================================
 
-During normal traversal (``visit_material``), each model on a ``Material`` is
-checked with ``BaseVisitor.is_supported``. A model is supported only when
-**both** of the following hold:
+During normal traversal (:meth:`~ansys.materials.manager.integrations.MaterialModelWriterVisitor.visit_material`),
+each model on a :class:`~ansys.materials.manager.models.Material` is checked with
+:meth:`~ansys.materials.manager.integrations.BaseVisitor.is_supported`. A model is
+supported only when **both** of the following hold:
 
 1. Its class is listed in the writer's ``_model_map``.
 2. The writer defines a ``visit`` handler that can dispatch to that class (via
    ``@singledispatchmethod`` or a plain override).
 
 Unsupported models are **skipped** (not raised) and a **warning** is logged so
-batch export can continue. Direct calls to ``MaterialModel.accept`` still
-dispatch through ``visit`` and may raise ``UnsupportedMaterialModelError`` when
+batch export can continue. Direct calls to :meth:`~ansys.materials.manager.models.MaterialModel.accept`
+still dispatch through ``visit`` and may raise
+:class:`~ansys.materials.manager.integrations.UnsupportedMaterialModelError` when
 no handler exists.
 
 
@@ -247,7 +256,8 @@ enough. Complex MAPDL or tabular output should always have a golden-file test.
 Further reading
 ===============
 
-- API reference for ``MaterialModelWriterVisitor``,
-  ``MaterialModelWriterVisitorProtocol``, ``BaseVisitor``, and concrete writers
+- API reference: :class:`~ansys.materials.manager.integrations.MaterialModelWriterVisitor`,
+  :class:`~ansys.materials.manager.models._common.visitor_protocol.MaterialModelWriterVisitorProtocol`,
+  :class:`~ansys.materials.manager.integrations.BaseVisitor`, and concrete writers
   (generated from docstrings).
-- Module overview: ``ansys.materials.manager.integrations``.
+- Module overview: :mod:`ansys.materials.manager.integrations`.

--- a/doc/source/developer_guide.rst
+++ b/doc/source/developer_guide.rst
@@ -64,7 +64,10 @@ Key types
      - Role
    * - :class:`~ansys.materials.manager.integrations.MaterialModelWriterVisitor`
      - ``integrations``
-     - Abstract visitor protocol (``visit``, ``visit_material``, ``is_supported``)
+     - Abstract visitor (``visit``, ``visit_material``, ``is_supported``)
+   * - :class:`~ansys.materials.manager.models._common.visitor_protocol.MaterialModelWriterVisitorProtocol`
+     - ``models._common.visitor_protocol``
+     - Structural typing protocol used by ``accept()`` (no integrations import)
    * - :class:`~ansys.materials.manager.integrations.BaseVisitor`
      - ``integrations``
      - Shared writer base: ``_model_map``, ``_populate_dependent_parameters``, traversal
@@ -79,9 +82,9 @@ Import boundary
 ---------------
 
 - ``integrations`` imports ``models``.
-- ``models`` **never** imports ``integrations``. ``MaterialModel.accept`` only
-  references a typing :class:`~ansys.materials.manager.models._common.visitor_protocol.MaterialModelWriterVisitor`
-  protocol.
+- ``models`` **never** imports ``integrations``. ``Material.accept`` and
+  ``MaterialModel.accept`` only reference
+  :class:`~ansys.materials.manager.models._common.visitor_protocol.MaterialModelWriterVisitorProtocol`.
 
 Each writer class defines its **own** ``@singledispatchmethod visit`` so handler
 registries are not shared across MatML, MAPDL, Fluent, and LS-DYNA.
@@ -215,6 +218,25 @@ update an entry in ``_get_material_card_map()`` keyed by the tuple of model
 classes present on a :class:`~ansys.materials.manager.models.Material`.
 
 
+``is_supported`` and unsupported models
+=======================================
+
+During normal traversal (:meth:`~ansys.materials.manager.integrations.MaterialModelWriterVisitor.visit_material`),
+each model on a :class:`~ansys.materials.manager.models.Material` is checked with
+:meth:`~ansys.materials.manager.integrations.BaseVisitor.is_supported`. A model is
+supported only when **both** of the following hold:
+
+1. Its class is listed in the writer's ``_model_map``.
+2. The writer defines a ``visit`` handler that can dispatch to that class (via
+   ``@singledispatchmethod`` or a plain override).
+
+Unsupported models are **skipped** (not raised) and a **warning** is logged so
+batch export can continue. Direct calls to :meth:`~ansys.materials.manager.models.MaterialModel.accept`
+still dispatch through ``visit`` and may raise
+:class:`~ansys.materials.manager.integrations.UnsupportedMaterialModelError` when
+no handler exists.
+
+
 Testing
 =======
 
@@ -235,6 +257,7 @@ Further reading
 ===============
 
 - API reference: :class:`~ansys.materials.manager.integrations.MaterialModelWriterVisitor`,
+  :class:`~ansys.materials.manager.models._common.visitor_protocol.MaterialModelWriterVisitorProtocol`,
   :class:`~ansys.materials.manager.integrations.BaseVisitor`, and concrete writers
   (generated from docstrings).
 - Module overview: :mod:`ansys.materials.manager.integrations`.

--- a/doc/source/developer_guide.rst
+++ b/doc/source/developer_guide.rst
@@ -8,9 +8,9 @@ This page describes how material **writers** serialize domain models using the
 `visitor pattern <https://en.wikipedia.org/wiki/Visitor_pattern>`_, and how to
 extend the library with new models or solver integrations.
 
-End users typically interact with :class:`~ansys.materials.manager.MaterialManager`
-and do not need to know about visitors. Contributors and anyone subclassing
-writers should read this guide.
+End users typically interact with ``MaterialManager`` and do not need to know
+about visitors. Contributors and anyone subclassing writers should read this
+guide.
 
 
 Writer visitor pattern
@@ -19,24 +19,21 @@ Writer visitor pattern
 Problem
 -------
 
-Material models (for example :class:`~ansys.materials.manager.models.Density`,
-:class:`~ansys.materials.manager.models.ElasticityIsotropic`) are
-solver-agnostic Pydantic objects in :mod:`ansys.materials.manager.models`.
-Writers in :mod:`ansys.materials.manager.integrations` must turn those objects
-into MatML XML, MAPDL command strings, Fluent dictionaries, or LS-DYNA keyword
-cards **without** importing solver logic into the model layer.
+Material models (for example ``Density`` and ``ElasticityIsotropic``) are
+solver-agnostic Pydantic objects in the ``models`` package. Writers in
+``integrations`` must turn those objects into MatML XML, MAPDL command strings,
+Fluent dictionaries, or LS-DYNA keyword cards **without** importing solver
+logic into the model layer.
 
-Solution: double dispatch
--------------------------
+Double dispatch
+---------------
 
 Traversal uses **double dispatch**. The model does not know which solver is
 targeted; the writer does not use long ``isinstance`` chains to pick behavior.
 
-1. A writer is constructed with a list of :class:`~ansys.materials.manager.models.Material`
-   instances.
-2. The writer calls :meth:`~ansys.materials.manager.models.Material.accept`.
-3. Each :class:`~ansys.materials.manager.models.MaterialModel` on that material
-   calls :meth:`~ansys.materials.manager.models.MaterialModel.accept`, which
+1. A writer is constructed with a list of ``Material`` instances.
+2. The writer calls ``Material.accept``.
+3. Each ``MaterialModel`` on that material calls ``MaterialModel.accept``, which
    delegates to ``visitor.visit(self, material_name=...)``.
 4. The writer's ``visit`` implementation (usually
    ``@functools.singledispatchmethod``) selects the handler for the concrete
@@ -62,16 +59,16 @@ Key types
    * - Type
      - Location
      - Role
-   * - :class:`~ansys.materials.manager.integrations.MaterialModelWriterVisitor`
+   * - ``MaterialModelWriterVisitor``
      - ``integrations``
      - Abstract visitor (``visit``, ``visit_material``, ``is_supported``)
-   * - :class:`~ansys.materials.manager.models._common.visitor_protocol.MaterialModelWriterVisitorProtocol`
+   * - ``MaterialModelWriterVisitorProtocol``
      - ``models._common.visitor_protocol``
      - Structural typing protocol used by ``accept()`` (no integrations import)
-   * - :class:`~ansys.materials.manager.integrations.BaseVisitor`
+   * - ``BaseVisitor``
      - ``integrations``
      - Shared writer base: ``_model_map``, ``_populate_dependent_parameters``, traversal
-   * - :class:`~ansys.materials.manager.integrations._common.ModelInfo`
+   * - ``ModelInfo``
      - ``integrations._common``
      - Declarative map from model fields to external labels (or ``method_write``)
    * - Concrete writers
@@ -83,8 +80,7 @@ Import boundary
 
 - ``integrations`` imports ``models``.
 - ``models`` **never** imports ``integrations``. ``Material.accept`` and
-  ``MaterialModel.accept`` only reference
-  :class:`~ansys.materials.manager.models._common.visitor_protocol.MaterialModelWriterVisitorProtocol`.
+  ``MaterialModel.accept`` only reference ``MaterialModelWriterVisitorProtocol``.
 
 Each writer class defines its **own** ``@singledispatchmethod visit`` so handler
 registries are not shared across MatML, MAPDL, Fluent, and LS-DYNA.
@@ -102,8 +98,7 @@ Most models only need a row in the writer's ``_*_model_map.py`` file:
        attributes=["python_field_name"],
    ),
 
-The default ``visit`` handler calls
-:meth:`~ansys.materials.manager.integrations.BaseVisitor._populate_dependent_parameters`,
+The default ``visit`` handler calls ``BaseVisitor._populate_dependent_parameters``,
 which reads ``_model_map``.
 
 When labels and fields do not map 1:1, use ``method_write``:
@@ -137,38 +132,37 @@ Only a small number of MAPDL models need this; the rest use the shared
 Readers are not visitors
 ========================
 
-MatML and REST **readers** build :class:`~ansys.materials.manager.models.MaterialModel`
-instances from external data. They use the same :class:`~ansys.materials.manager.integrations._common.ModelInfo`
-maps (with ``method_read`` where needed) but **do not** call ``accept()``.
-Dispatch is keyed by XML property names or Granta MI model IDs, not by existing
-model instances.
+MatML and REST **readers** build ``MaterialModel`` instances from external data.
+They use the same ``ModelInfo`` maps (with ``method_read`` where needed) but
+**do not** call ``accept()``. Dispatch is keyed by XML property names or Granta
+MI model IDs, not by existing model instances.
 
 
 Adding a new material model
 ===========================
 
-Use this checklist when introducing a new domain concept (a new
-:class:`~ansys.materials.manager.models.MaterialModel` subclass).
+Use this checklist when introducing a new domain concept (a new ``MaterialModel``
+subclass).
 
 1. **Define the model** in ``src/ansys/materials/manager/models/_material_models/``.
 
-   - Subclass :class:`~ansys.materials.manager.models.MaterialModel`.
+   - Subclass ``MaterialModel``.
    - Set a frozen ``name: Literal["..."]``, fields, and ``supported_packages``.
    - Do **not** override ``accept()``; it is inherited from the base class.
 
 2. **Export** the class from ``models/_material_models/__init__.py`` (and thus
    ``models.__all__``).
 
-3. **MatML (canonical interchange)** — add an entry to
+3. **MatML (canonical interchange)**: add an entry to
    ``integrations/matml/_matml_model_map.py``. One entry covers MatML read and write.
 
-4. **REST / Granta MI** (if applicable) — add ``MODEL_ID_MAP`` and
+4. **REST / Granta MI** (if applicable): add ``MODEL_ID_MAP`` and
    ``MATERIAL_MODEL_MAP`` entries in ``integrations/rest/_rest_model_map.py``.
 
-5. **Per-solver writer maps** — see :ref:`ref_add_solver_support` for each target
+5. **Per-solver writer maps**: see :ref:`ref_add_solver_support` for each target
    (MAPDL, Fluent, LS-DYNA).
 
-6. **Tests** — golden-file tests under ``tests/matml/``, ``tests/mapdl/``, etc.
+6. **Tests**: golden-file tests under ``tests/matml/``, ``tests/mapdl/``, etc.
    Add a ``minimal_model_factory`` entry in ``tests/integrations/conftest.py`` so
    map-coverage smoke tests pick up the new type (optional but recommended).
 
@@ -192,8 +186,7 @@ serialization or LS-DYNA card composition.
      - Usually already present if the model exists
    * - MAPDL
      - ``integrations/mapdl/_mapdl_model_map.py``
-     - ``@visit.register`` only for non-standard output (see
-       :class:`~ansys.materials.manager.integrations.mapdl.MapdlWriter`)
+     - ``@visit.register`` only for non-standard output (see ``MapdlWriter``)
    * - Fluent
      - ``integrations/fluent/_fluent_model_map.py``
      - Map entry only
@@ -212,28 +205,26 @@ serialization or LS-DYNA card composition.
 After adding the map entry, the writer's default ``visit`` handler serializes the
 model. No changes to ``MapdlWriter`` are required.
 
-**LS-DYNA card composition** — LS-DYNA merges multiple models into one keyword
+**LS-DYNA card composition**: LS-DYNA merges multiple models into one keyword
 card. Ensure each constituent model is in ``_ls_dyna_model_map.py``, then add or
 update an entry in ``_get_material_card_map()`` keyed by the tuple of model
-classes present on a :class:`~ansys.materials.manager.models.Material`.
+classes present on a ``Material``.
 
 
 ``is_supported`` and unsupported models
 =======================================
 
-During normal traversal (:meth:`~ansys.materials.manager.integrations.MaterialModelWriterVisitor.visit_material`),
-each model on a :class:`~ansys.materials.manager.models.Material` is checked with
-:meth:`~ansys.materials.manager.integrations.BaseVisitor.is_supported`. A model is
-supported only when **both** of the following hold:
+During normal traversal (``visit_material``), each model on a ``Material`` is
+checked with ``BaseVisitor.is_supported``. A model is supported only when
+**both** of the following hold:
 
 1. Its class is listed in the writer's ``_model_map``.
 2. The writer defines a ``visit`` handler that can dispatch to that class (via
    ``@singledispatchmethod`` or a plain override).
 
 Unsupported models are **skipped** (not raised) and a **warning** is logged so
-batch export can continue. Direct calls to :meth:`~ansys.materials.manager.models.MaterialModel.accept`
-still dispatch through ``visit`` and may raise
-:class:`~ansys.materials.manager.integrations.UnsupportedMaterialModelError` when
+batch export can continue. Direct calls to ``MaterialModel.accept`` still
+dispatch through ``visit`` and may raise ``UnsupportedMaterialModelError`` when
 no handler exists.
 
 
@@ -242,22 +233,21 @@ Testing
 
 Use a **layered** approach:
 
-1. **Visitor mechanics** — ``tests/integrations/test_visitor_dispatch.py`` (fast
+1. **Visitor mechanics**: ``tests/integrations/test_visitor_dispatch.py`` (fast
    dispatch and ``accept`` wiring).
-2. **Map coverage** — ``tests/integrations/test_writer_map_coverage.py``
+2. **Map coverage**: ``tests/integrations/test_writer_map_coverage.py``
    (parametrized smoke test per writer map).
-3. **Format golden files** — existing tests under ``tests/matml/``, ``tests/mapdl/``,
+3. **Format golden files**: existing tests under ``tests/matml/``, ``tests/mapdl/``,
    etc. (prove correct XML / APDL / Fluent / LS-DYNA output).
 
-For a new simple map entry, layers 1–2 plus an optional golden file are usually
+For a new simple map entry, layers 1-2 plus an optional golden file are usually
 enough. Complex MAPDL or tabular output should always have a golden-file test.
 
 
 Further reading
 ===============
 
-- API reference: :class:`~ansys.materials.manager.integrations.MaterialModelWriterVisitor`,
-  :class:`~ansys.materials.manager.models._common.visitor_protocol.MaterialModelWriterVisitorProtocol`,
-  :class:`~ansys.materials.manager.integrations.BaseVisitor`, and concrete writers
+- API reference for ``MaterialModelWriterVisitor``,
+  ``MaterialModelWriterVisitorProtocol``, ``BaseVisitor``, and concrete writers
   (generated from docstrings).
-- Module overview: :mod:`ansys.materials.manager.integrations`.
+- Module overview: ``ansys.materials.manager.integrations``.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -10,4 +10,5 @@
    :maxdepth: 3
 
    api/index
+   developer_guide
    contributing

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -9,3 +9,6 @@ uv
 Synopsys
 synopsys
 SYNOPSYS
+Pydantic
+subclassing
+docstrings

--- a/src/ansys/materials/manager/integrations/__init__.py
+++ b/src/ansys/materials/manager/integrations/__init__.py
@@ -20,21 +20,40 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""External system integrations for reading and writing materials."""
+"""External system integrations for reading and writing materials.
+
+Domain models live in :mod:`ansys.materials.manager.models`. Writers in this
+package traverse those models using the `visitor pattern
+<https://en.wikipedia.org/wiki/Visitor_pattern>`_: each
+:class:`~.MaterialModel` calls :meth:`~ansys.materials.manager.models.MaterialModel.accept`
+on a writer, which dispatches to :meth:`~.MaterialModelWriterVisitor.visit`.
+
+For extension or custom writers, subclass :class:`~.BaseVisitor`, define a
+``@functools.singledispatchmethod visit`` on the subclass, and register handlers
+with ``@visit.register(MyModel)``. Most models only need a
+:class:`~._common.ModelInfo` entry in the writer's ``_model_map``. See
+``doc/source/developer_guide.rst`` for a full contributor guide.
+
+Readers (MatML, REST) deserialize external data into models via ``ModelInfo``
+maps and do not use ``accept()``.
+"""
 
 from .base_visitor import BaseVisitor
 from .fluent import FluentWriter
 from .lsdyna import LsDynaWriter
 from .mapdl import MapdlWriter, read_mapdl
 from .matml import MatmlReader, MatmlWriter
+from .material_model_writer_visitor import MaterialModelWriterVisitor, UnsupportedMaterialModelError
 
 __all__ = [
     "BaseVisitor",
     "FluentWriter",
     "LsDynaWriter",
     "MapdlWriter",
+    "MaterialModelWriterVisitor",
     "MatmlReader",
     "MatmlWriter",
+    "UnsupportedMaterialModelError",
     "read_mapdl",
 ]
 

--- a/src/ansys/materials/manager/integrations/__init__.py
+++ b/src/ansys/materials/manager/integrations/__init__.py
@@ -42,8 +42,8 @@ from .base_visitor import BaseVisitor
 from .fluent import FluentWriter
 from .lsdyna import LsDynaWriter
 from .mapdl import MapdlWriter, read_mapdl
-from .matml import MatmlReader, MatmlWriter
 from .material_model_writer_visitor import MaterialModelWriterVisitor, UnsupportedMaterialModelError
+from .matml import MatmlReader, MatmlWriter
 
 __all__ = [
     "BaseVisitor",

--- a/src/ansys/materials/manager/integrations/base_visitor.py
+++ b/src/ansys/materials/manager/integrations/base_visitor.py
@@ -140,7 +140,8 @@ class BaseVisitor(MaterialModelWriterVisitor):
         """Return whether ``visit`` can dispatch for ``model_cls``."""
         registry = _visit_registry(type(self))
         if registry is not None:
-            return any(cls in registry for cls in model_cls.__mro__)
+            registered = {cls for cls in registry if cls is not object}
+            return any(cls in registered for cls in model_cls.__mro__)
         if "visit" in type(self).__dict__:
             visit_attr = type(self).__dict__["visit"]
             if not isinstance(visit_attr, functools.singledispatchmethod):
@@ -154,7 +155,7 @@ class BaseVisitor(MaterialModelWriterVisitor):
             if mapping.method_write:
                 labels, quantities = mapping.method_write(material_model)
             else:
-                if not mapping.labels and not mapping.attributes:
+                if not mapping.labels or not mapping.attributes:
                     return {}
                 labels = mapping.labels
                 quantities = [getattr(material_model, label) for label in mapping.attributes]

--- a/src/ansys/materials/manager/integrations/base_visitor.py
+++ b/src/ansys/materials/manager/integrations/base_visitor.py
@@ -20,21 +20,69 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from abc import abstractmethod
-import sys
+import warnings
+from typing import Any
 
 from ..models import Material, MaterialModel
+from ._common import ModelInfo
+from .material_model_writer_visitor import (
+    MaterialModelWriterVisitor,
+    UnsupportedMaterialModelError,
+)
 
-MATERIAL_MODEL_MAP = {}
 
+class BaseVisitor(MaterialModelWriterVisitor):
+    """Base class for format-specific material writers.
 
-class BaseVisitor:
-    """Base visitor. All visitors should inherit from this class."""
+    Writers subclass this class and implement serialization by defining a
+    ``@functools.singledispatchmethod`` named ``visit`` on the writer subclass,
+    then registering handlers with ``@visit.register(MyModel)``. A default
+    handler for :class:`~ansys.materials.manager.models.MaterialModel` that reads
+    ``_model_map`` is enough for most models.
 
-    def __init__(self, materials: list[Material]):
+    Construction stores materials and initializes ``_material_repr``, a
+    ``dict[str, list]`` that accumulates per-material output fragments.
+    Call :meth:`visit_materials` (or rely on the subclass ``__init__``) to
+    traverse via :meth:`~ansys.materials.manager.models.Material.accept`.
+
+    Parameters
+    ----------
+    materials : list[Material]
+        Materials to serialize.
+    model_map : dict[type, ModelInfo] | None
+        Maps concrete model classes to :class:`~.ModelInfo` descriptors.
+        Declares which models the writer supports and how fields map to
+        external labels.
+
+    Examples
+    --------
+    Register a custom handler on a writer subclass::
+
+        class MyMapdlWriter(BaseVisitor):
+            @singledispatchmethod
+            def visit(self, model: MaterialModel, *, material_name: str) -> None:
+                raise UnsupportedMaterialModelError(...)
+
+            @visit.register(Density)
+            def _visit_density(self, model: Density, *, material_name: str) -> None:
+                ...
+
+    See Also
+    --------
+    MaterialModelWriterVisitor : Visitor protocol and traversal contract.
+    MaterialModel.accept : Model-side dispatch entry point.
+    ref_developer_guide : Contributor guide for adding models and solver maps.
+  """
+
+    def __init__(
+        self,
+        materials: list[Material],
+        model_map: dict[type, ModelInfo] | None = None,
+    ):
         """Initialize the base visitor."""
         self._materials: list[Material] = materials
         self._material_repr: dict = {material.name: [] for material in materials}
+        self._model_map: dict[type, ModelInfo] = model_map if model_map is not None else {}
 
     def get_material_id(self, material_name) -> int:
         """
@@ -68,19 +116,12 @@ class BaseVisitor:
         bool
             True if the material model is supported, False otherwise.
         """
-        module = sys.modules[self.__module__]
-        mapping = getattr(module, "MATERIAL_MODEL_MAP")
-        if material_model.__class__ in mapping.keys():
-            return True
-        else:
-            return False
+        return material_model.__class__ in self._model_map
 
     def _populate_dependent_parameters(self, material_model: MaterialModel) -> dict:
         """Populate dependent parameters with quantity-like values."""
-        module = sys.modules[self.__module__]
-        model_map = getattr(module, "MATERIAL_MODEL_MAP")
-        if material_model.__class__ in model_map.keys():
-            mapping = model_map[material_model.__class__]
+        if material_model.__class__ in self._model_map:
+            mapping = self._model_map[material_model.__class__]
             if mapping.method_write:
                 labels, quantities = mapping.method_write(material_model)
             else:
@@ -89,19 +130,44 @@ class BaseVisitor:
                 labels = mapping.labels
                 quantities = [getattr(material_model, label) for label in mapping.attributes]
             return {label: qty for label, qty in zip(labels, quantities) if qty is not None}
+        return {}
 
-    @abstractmethod
-    def visit_material_model(self, material_name: str, material_model: MaterialModel):
-        """Abstract implementation of the visit material model."""
-        raise NotImplementedError()
+    def visit(self, model: MaterialModel, *, material_name: str) -> Any:
+        """Dispatch serialization for a material model.
 
-    def visit_materials(self):
-        """Visit materials."""
+        Concrete writers override this method (typically with
+        ``@functools.singledispatchmethod``) to provide format-specific handlers.
+        """
+        raise UnsupportedMaterialModelError(
+            f"{type(self).__name__} has no visit handler for {model.__class__.__name__}"
+        )
+
+    def visit_materials(self) -> None:
+        """Visit all materials using double dispatch via :meth:`~.Material.accept`."""
         for material in self._materials:
-            for material_model in material.models:
-                if not self.is_supported(material_model):
-                    print(
-                        f"Material model: {material_model.__class__.__name__} not supported by {self.__class__.__name__}"  # noqa: E501
-                    )
-                    continue
-                self.visit_material_model(material.name, material_model)
+            material.accept(self)
+
+    def visit_material_model(self, material_name: str, material_model: MaterialModel) -> Any:
+        """Visit a single material model.
+
+        .. deprecated::
+            Use :meth:`visit` via :meth:`~.MaterialModel.accept` instead.
+
+        Parameters
+        ----------
+        material_name : str
+            Name of the parent material.
+        material_model : MaterialModel
+            Model to visit.
+
+        Returns
+        -------
+        Any
+            Result from :meth:`visit`.
+        """
+        warnings.warn(
+            "visit_material_model is deprecated; traversal uses MaterialModel.accept and visit.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return material_model.accept(self, material_name=material_name)

--- a/src/ansys/materials/manager/integrations/base_visitor.py
+++ b/src/ansys/materials/manager/integrations/base_visitor.py
@@ -20,8 +20,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import warnings
+import functools
 from typing import Any
+import warnings
 
 from ..models import Material, MaterialModel
 from ._common import ModelInfo
@@ -29,6 +30,16 @@ from .material_model_writer_visitor import (
     MaterialModelWriterVisitor,
     UnsupportedMaterialModelError,
 )
+
+
+def _visit_registry(visitor_cls: type) -> dict | None:
+    """Return the singledispatch registry for a writer's ``visit`` method, if any."""
+    visit = visitor_cls.__dict__.get("visit")
+    if visit is None:
+        return None
+    if isinstance(visit, functools.singledispatchmethod):
+        return visit.dispatcher.registry
+    return None
 
 
 class BaseVisitor(MaterialModelWriterVisitor):
@@ -72,7 +83,7 @@ class BaseVisitor(MaterialModelWriterVisitor):
     MaterialModelWriterVisitor : Visitor protocol and traversal contract.
     MaterialModel.accept : Model-side dispatch entry point.
     ref_developer_guide : Contributor guide for adding models and solver maps.
-  """
+    """
 
     def __init__(
         self,
@@ -106,6 +117,10 @@ class BaseVisitor(MaterialModelWriterVisitor):
         """
         Check if the material model is supported.
 
+        A model is supported when it appears in ``_model_map`` **and** the
+        writer defines a ``visit`` handler for its concrete type (via
+        ``@singledispatchmethod`` or a plain override).
+
         Parameters
         ----------
         material_model : MaterialModel
@@ -116,7 +131,21 @@ class BaseVisitor(MaterialModelWriterVisitor):
         bool
             True if the material model is supported, False otherwise.
         """
-        return material_model.__class__ in self._model_map
+        model_cls = material_model.__class__
+        if model_cls not in self._model_map:
+            return False
+        return self._has_visit_handler(model_cls)
+
+    def _has_visit_handler(self, model_cls: type) -> bool:
+        """Return whether ``visit`` can dispatch for ``model_cls``."""
+        registry = _visit_registry(type(self))
+        if registry is not None:
+            return any(cls in registry for cls in model_cls.__mro__)
+        if "visit" in type(self).__dict__:
+            visit_attr = type(self).__dict__["visit"]
+            if not isinstance(visit_attr, functools.singledispatchmethod):
+                return visit_attr is not BaseVisitor.__dict__["visit"]
+        return False
 
     def _populate_dependent_parameters(self, material_model: MaterialModel) -> dict:
         """Populate dependent parameters with quantity-like values."""

--- a/src/ansys/materials/manager/integrations/fluent/fluent_writer.py
+++ b/src/ansys/materials/manager/integrations/fluent/fluent_writer.py
@@ -20,17 +20,20 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from ...models import Density, Material, MaterialModel, MolecularWeight
+from functools import singledispatchmethod
+
+from ...models import Material, MaterialModel
 from ..base_visitor import BaseVisitor
-from ._fluent_model_map import MATERIAL_MODEL_MAP  # noqa: F401
+from ..material_model_writer_visitor import UnsupportedMaterialModelError
+from ._fluent_model_map import MATERIAL_MODEL_MAP
 
 
 class FluentWriter(BaseVisitor):
-    """Fluent writer."""
+    """Write materials to Fluent solver representation via the visitor pattern."""
 
     def __init__(self, materials: list[Material]):
         """Initialize the fluent writer."""
-        super().__init__(materials=materials)
+        super().__init__(materials=materials, model_map=MATERIAL_MODEL_MAP)
         self.visit_materials()
 
     def _standard_write(self, material_model: MaterialModel) -> dict:
@@ -43,20 +46,18 @@ class FluentWriter(BaseVisitor):
             model.update(new_model)
         return model
 
-    def visit_material_model(self, material_name: str, material_model: MaterialModel) -> None:
-        """
-        Visit the material model.
+    @singledispatchmethod
+    def visit(self, material_model: MaterialModel, *, material_name: str) -> None:
+        """Dispatch Fluent serialization by model type."""
+        raise UnsupportedMaterialModelError(
+            f"{type(self).__name__} has no visit handler for {material_model.__class__.__name__}"
+        )
 
-        Parameters
-        ----------
-        material_name : str
-            Name of the material.
-        material_model : MaterialModel
-            Material model to visit.
-        """
-        if isinstance(material_model, (Density, MolecularWeight)):
-            model = self._standard_write(material_model)
-            self._material_repr[material_name].append(model)
+    @visit.register(MaterialModel)
+    def _visit_material_model(self, material_model: MaterialModel, *, material_name: str) -> None:
+        """Visit supported Fluent material models."""
+        model = self._standard_write(material_model)
+        self._material_repr[material_name].append(model)
 
     def write(self, material_names: list[str] | None = None) -> list[dict]:
         """

--- a/src/ansys/materials/manager/integrations/lsdyna/lsdyna_writer.py
+++ b/src/ansys/materials/manager/integrations/lsdyna/lsdyna_writer.py
@@ -20,13 +20,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from functools import singledispatchmethod
+
 # Build writing registry
 from typing import Sequence
 
 import numpy as np
-from functools import singledispatchmethod
 
-from ..base_visitor import BaseVisitor
 from ...models import (
     Density,
     ElasticityAnisotropic,
@@ -37,6 +37,7 @@ from ...models import (
 )
 from ...models._common import _DynaDeck, _DynaKeywordBase
 from .._common import get_model_attributes, normalize_key
+from ..base_visitor import BaseVisitor
 from ..material_model_writer_visitor import UnsupportedMaterialModelError
 from ._ls_dyna_model_map import MATERIAL_MODEL_MAP
 

--- a/src/ansys/materials/manager/integrations/lsdyna/lsdyna_writer.py
+++ b/src/ansys/materials/manager/integrations/lsdyna/lsdyna_writer.py
@@ -24,18 +24,21 @@
 from typing import Sequence
 
 import numpy as np
+from functools import singledispatchmethod
 
-from .. import BaseVisitor
+from ..base_visitor import BaseVisitor
 from ...models import (
     Density,
     ElasticityAnisotropic,
     ElasticityIsotropic,
     ElasticityOrthotropic,
     Material,
+    MaterialModel,
 )
 from ...models._common import _DynaDeck, _DynaKeywordBase
 from .._common import get_model_attributes, normalize_key
-from ._ls_dyna_model_map import MATERIAL_MODEL_MAP  # noqa: F401
+from ..material_model_writer_visitor import UnsupportedMaterialModelError
+from ._ls_dyna_model_map import MATERIAL_MODEL_MAP
 
 _MATERIAL_CARD_MAP = None
 
@@ -58,25 +61,29 @@ def _get_material_card_map():
 
 
 class LsDynaWriter(BaseVisitor):
-    """Ls Dyna writer."""
+    """Write materials to LS-DYNA keyword cards via the visitor pattern."""
 
     _material_models_per_material: dict
 
     def __init__(self, materials: list[Material]):
         """Initialize the ls dyna writer."""
-        super().__init__(materials=materials)
+        super().__init__(materials=materials, model_map=MATERIAL_MODEL_MAP)
         self._material_models_per_material: dict = {material.name: [] for material in materials}
         self.visit_materials()
 
-    def visit_material_model(self, material_name, material_model):
-        """Visit material model."""
-        if isinstance(
-            material_model,
-            (Density, ElasticityIsotropic, ElasticityOrthotropic, ElasticityAnisotropic),
-        ):
-            model = self._populate_dependent_parameters(material_model)
-            self._material_repr[material_name].append(model)
-            self._material_models_per_material[material_name].append(material_model.__class__)
+    @singledispatchmethod
+    def visit(self, material_model: MaterialModel, *, material_name: str) -> None:
+        """Dispatch LS-DYNA parameter collection by model type."""
+        raise UnsupportedMaterialModelError(
+            f"{type(self).__name__} has no visit handler for {material_model.__class__.__name__}"
+        )
+
+    @visit.register(MaterialModel)
+    def _visit_material_model(self, material_model: MaterialModel, *, material_name: str) -> None:
+        """Collect per-model parameters for LS-DYNA card composition."""
+        model = self._populate_dependent_parameters(material_model)
+        self._material_repr[material_name].append(model)
+        self._material_models_per_material[material_name].append(material_model.__class__)
 
     def _to_material_models(self) -> list[_DynaKeywordBase]:
         """Bring to material models."""

--- a/src/ansys/materials/manager/integrations/mapdl/mapdl_writer.py
+++ b/src/ansys/materials/manager/integrations/mapdl/mapdl_writer.py
@@ -20,8 +20,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import numpy as np
 from functools import singledispatchmethod
+
+import numpy as np
 
 from ...models import (
     Density,

--- a/src/ansys/materials/manager/integrations/mapdl/mapdl_writer.py
+++ b/src/ansys/materials/manager/integrations/mapdl/mapdl_writer.py
@@ -21,23 +21,19 @@
 # SOFTWARE.
 
 import numpy as np
+from functools import singledispatchmethod
 
 from ...models import (
-    CoefficientofThermalExpansionIsotropic,
-    CoefficientofThermalExpansionOrthotropic,
     Density,
     ElasticityAnisotropic,
-    ElasticityIsotropic,
-    ElasticityOrthotropic,
     HillYieldCriterion,
     IsotropicHardening,
     Material,
     MaterialModel,
-    ThermalConductivityIsotropic,
-    ThermalConductivityOrthotropic,
 )
 from ...models._common import _MapdlCore
 from ..base_visitor import BaseVisitor
+from ..material_model_writer_visitor import UnsupportedMaterialModelError
 from ._mapdl_commands_parser import (
     TABLE_LABELS,
     TABLE_TBOPT,
@@ -52,15 +48,15 @@ from ._mapdl_commands_parser import (
     write_temperature_reference_value,
     write_temperature_table_values,
 )
-from ._mapdl_model_map import MATERIAL_MODEL_MAP  # noqa: F401
+from ._mapdl_model_map import MATERIAL_MODEL_MAP
 
 
 class MapdlWriter(BaseVisitor):
-    """Mapdl writer."""
+    """Write materials to MAPDL APDL command strings via the visitor pattern."""
 
     def __init__(self, materials: list[Material]):
         """Initialize the Mapdl visitor."""
-        super().__init__(materials=materials)
+        super().__init__(materials=materials, model_map=MATERIAL_MODEL_MAP)
         self.visit_materials()
 
     def _write_standard(self, material_model: MaterialModel) -> str:
@@ -243,27 +239,41 @@ class MapdlWriter(BaseVisitor):
 
         return material_string
 
-    def visit_material_model(self, material_name: str, material_model: MaterialModel) -> None:
-        """Visit material model."""
-        standard_models = (
-            Density,
-            ElasticityIsotropic,
-            ElasticityOrthotropic,
-            CoefficientofThermalExpansionIsotropic,
-            CoefficientofThermalExpansionOrthotropic,
-            ThermalConductivityIsotropic,
-            ThermalConductivityOrthotropic,
+    @singledispatchmethod
+    def visit(self, material_model: MaterialModel, *, material_name: str) -> None:
+        """Dispatch MAPDL serialization by model type."""
+        raise UnsupportedMaterialModelError(
+            f"{type(self).__name__} has no visit handler for {material_model.__class__.__name__}"
         )
-        if isinstance(material_model, standard_models):
-            model = self.visit_standard(material_model)
-        elif isinstance(material_model, ElasticityAnisotropic):
-            model = self.visit_anisotropic(material_model)
-        elif isinstance(material_model, HillYieldCriterion):
-            model = self.visit_hill_yield_criterion(material_model)
-        elif isinstance(material_model, IsotropicHardening):
-            model = self.visit_isotropic_harderning(material_model)
-        else:
-            return
+
+    @visit.register(MaterialModel)
+    def _visit_standard_model(self, material_model: MaterialModel, *, material_name: str) -> None:
+        """Visit standard MAPDL material models."""
+        model = self.visit_standard(material_model)
+        self._material_repr[material_name].append(model)
+
+    @visit.register(ElasticityAnisotropic)
+    def _visit_anisotropic_model(
+        self, material_model: ElasticityAnisotropic, *, material_name: str
+    ) -> None:
+        """Visit anisotropic elasticity."""
+        model = self.visit_anisotropic(material_model)
+        self._material_repr[material_name].append(model)
+
+    @visit.register(HillYieldCriterion)
+    def _visit_hill_yield_model(
+        self, material_model: HillYieldCriterion, *, material_name: str
+    ) -> None:
+        """Visit Hill yield criterion."""
+        model = self.visit_hill_yield_criterion(material_model)
+        self._material_repr[material_name].append(model)
+
+    @visit.register(IsotropicHardening)
+    def _visit_isotropic_hardening_model(
+        self, material_model: IsotropicHardening, *, material_name: str
+    ) -> None:
+        """Visit isotropic hardening."""
+        model = self.visit_isotropic_harderning(material_model)
         self._material_repr[material_name].append(model)
 
     def write(

--- a/src/ansys/materials/manager/integrations/material_model_writer_visitor.py
+++ b/src/ansys/materials/manager/integrations/material_model_writer_visitor.py
@@ -29,8 +29,8 @@ format-specific output.
 Traversal uses double dispatch::
 
     material.accept(writer)            # ``Material`` iterates its models
-    model.accept(writer, name=...)     # delegates to ``writer.visit(model)``
-    writer.visit(model, name=...)      # dispatches by concrete model type
+    model.accept(writer, material_name=...)     # delegates to ``writer.visit(model)``
+    writer.visit(model, material_name=...)      # dispatches by concrete model type
 
 Most model types need only a ``ModelInfo`` entry in the writer's
 ``_model_map``. Override ``visit`` with ``@visit.register(MyModel)`` when
@@ -47,9 +47,12 @@ ModelInfo : Declarative field-to-label mapping.
 """
 
 from abc import ABC, abstractmethod
+import logging
 from typing import Any
 
 from ..models import Material, MaterialModel
+
+_logger = logging.getLogger(__name__)
 
 
 class UnsupportedMaterialModelError(TypeError):
@@ -92,9 +95,10 @@ class MaterialModelWriterVisitor(ABC):
         """
         for material_model in material.models:
             if not self.is_supported(material_model):
-                print(
-                    f"Material model: {material_model.__class__.__name__} not supported by "
-                    f"{self.__class__.__name__}"
+                _logger.warning(
+                    "Material model %s not supported by %s",
+                    material_model.__class__.__name__,
+                    self.__class__.__name__,
                 )
                 continue
             material_model.accept(self, material_name=material.name)

--- a/src/ansys/materials/manager/integrations/material_model_writer_visitor.py
+++ b/src/ansys/materials/manager/integrations/material_model_writer_visitor.py
@@ -1,0 +1,104 @@
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Writer visitor protocol for serializing material models.
+
+Material models are solver-agnostic domain objects. Writers (MatML, MAPDL,
+Fluent, LS-DYNA) are *visitors*: they traverse a ``Material`` and produce
+format-specific output.
+
+Traversal uses double dispatch::
+
+    material.accept(writer)            # ``Material`` iterates its models
+    model.accept(writer, name=...)     # delegates to ``writer.visit(model)``
+    writer.visit(model, name=...)      # dispatches by concrete model type
+
+Most model types need only a ``ModelInfo`` entry in the writer's
+``_model_map``. Override ``visit`` with ``@visit.register(MyModel)`` when
+serialization logic cannot be expressed as a label/attribute map.
+
+Each concrete writer defines its own ``@singledispatchmethod visit`` so
+handler registries are not shared across writer classes.
+
+See Also
+--------
+MaterialModel.accept : Entry point on the model side.
+BaseVisitor : Shared writer infrastructure.
+ModelInfo : Declarative field-to-label mapping.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from ..models import Material, MaterialModel
+
+
+class UnsupportedMaterialModelError(TypeError):
+    """Raised when a writer has no handler for a material model type."""
+
+
+class MaterialModelWriterVisitor(ABC):
+    """Protocol for writers that serialize :class:`~.MaterialModel` instances.
+
+    Subclasses implement format-specific output by defining a
+    ``@functools.singledispatchmethod`` named ``visit`` and registering
+    handlers (``@visit.register(MyModel)``), or by overriding ``visit``
+    directly for a single code path.
+    """
+
+    @abstractmethod
+    def visit(self, model: MaterialModel, *, material_name: str) -> Any:
+        """Dispatch serialization for a single material model.
+
+        Parameters
+        ----------
+        model : MaterialModel
+            The model instance to serialize.
+        material_name : str
+            Name of the parent :class:`~.Material`, used to group output.
+
+        Raises
+        ------
+        UnsupportedMaterialModelError
+            If no handler is registered for the model's concrete type.
+        """
+
+    def visit_material(self, material: Material) -> None:
+        """Visit every supported model on a material.
+
+        Parameters
+        ----------
+        material : Material
+            Material whose models should be serialized.
+        """
+        for material_model in material.models:
+            if not self.is_supported(material_model):
+                print(
+                    f"Material model: {material_model.__class__.__name__} not supported by "
+                    f"{self.__class__.__name__}"
+                )
+                continue
+            material_model.accept(self, material_name=material.name)
+
+    @abstractmethod
+    def is_supported(self, material_model: MaterialModel) -> bool:
+        """Return whether this writer supports the given model type."""

--- a/src/ansys/materials/manager/integrations/matml/matml_writer.py
+++ b/src/ansys/materials/manager/integrations/matml/matml_writer.py
@@ -23,10 +23,13 @@
 from typing import Optional
 import xml.etree.ElementTree as ET
 
+from functools import singledispatchmethod
+
 from ansys.units import Quantity
 
 from . import _matml_strings as _matml_strings
-from .. import BaseVisitor
+from ..base_visitor import BaseVisitor
+from ..material_model_writer_visitor import UnsupportedMaterialModelError
 from ...models import (
     IndependentParameter,
     InterpolationOptions,
@@ -36,7 +39,7 @@ from ...models import (
     UserParameter,
 )
 from .._common import _PATH_TYPE
-from ._matml_model_map import MATERIAL_MODEL_MAP  # noqa: F401
+from ._matml_model_map import MATERIAL_MODEL_MAP
 from ._matml_parser import (
     convert_to_float_string,
     create_xml_string_value,
@@ -45,7 +48,12 @@ from ._matml_parser import (
 
 
 class MatmlWriter(BaseVisitor):
-    """MatmlWriter."""
+    """Write materials to MatML XML using the visitor pattern.
+
+    On construction, each supported :class:`~.MaterialModel` on the given
+    materials is visited via :meth:`~.MaterialModel.accept`. Output XML
+    fragments are stored in ``_material_repr`` until :meth:`write` is called.
+    """
 
     _metadata_property_sets: dict
     _metadata_parameters: dict
@@ -54,12 +62,27 @@ class MatmlWriter(BaseVisitor):
 
     def __init__(self, materials: list[Material]):
         """Initialize the class."""
-        super().__init__(materials=materials)
+        super().__init__(materials=materials, model_map=MATERIAL_MODEL_MAP)
         self._metadata_parameters = {}
         self._metadata_property_sets = {}
         self._metadata_parameters_units = {}
         self._metadata_property_sets_units = {}
         self.visit_materials()
+
+    @singledispatchmethod
+    def visit(self, material_model: MaterialModel, *, material_name: str):
+        """Dispatch MatML serialization by model type."""
+        raise UnsupportedMaterialModelError(
+            f"{type(self).__name__} has no visit handler for {material_model.__class__.__name__}"
+        )
+
+    @visit.register(MaterialModel)
+    def _visit_material_model(self, material_model: MaterialModel, *, material_name: str):
+        """Serialize a material model to a MatML property data element."""
+        property_id = self._get_property_id(material_model.name)
+        material_element = self._visit_model(property_id, material_model)
+        self._material_repr[material_name].append(material_element)
+        return material_element
 
     def _get_property_id(self, property_name: str) -> str:
         """Get property id."""
@@ -358,14 +381,6 @@ class MatmlWriter(BaseVisitor):
             ET.indent(tree)
         else:
             print(f"ElementTree does not have `indent`. Python 3.9+ required!")
-
-    def visit_material_model(self, material_name: str, material_model: MaterialModel) -> ET.Element:
-        """Visit the material model."""
-        material_element = None
-        property_id = self._get_property_id(material_model.name)
-        material_element = self._visit_model(property_id, material_model)
-        self._material_repr[material_name].append(material_element)
-        return material_element
 
     def write(
         self,

--- a/src/ansys/materials/manager/integrations/matml/matml_writer.py
+++ b/src/ansys/materials/manager/integrations/matml/matml_writer.py
@@ -20,16 +20,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from functools import singledispatchmethod
 from typing import Optional
 import xml.etree.ElementTree as ET
-
-from functools import singledispatchmethod
 
 from ansys.units import Quantity
 
 from . import _matml_strings as _matml_strings
-from ..base_visitor import BaseVisitor
-from ..material_model_writer_visitor import UnsupportedMaterialModelError
 from ...models import (
     IndependentParameter,
     InterpolationOptions,
@@ -39,6 +36,8 @@ from ...models import (
     UserParameter,
 )
 from .._common import _PATH_TYPE
+from ..base_visitor import BaseVisitor
+from ..material_model_writer_visitor import UnsupportedMaterialModelError
 from ._matml_model_map import MATERIAL_MODEL_MAP
 from ._matml_parser import (
     convert_to_float_string,

--- a/src/ansys/materials/manager/models/_common/material_model.py
+++ b/src/ansys/materials/manager/models/_common/material_model.py
@@ -35,7 +35,7 @@ from .independent_parameter import IndependentParameter
 from .interpolation_options import InterpolationOptions
 from .model_qualifier import ModelQualifier
 from .tabular_quantity import TabularQuantity
-from .visitor_protocol import MaterialModelWriterVisitor
+from .visitor_protocol import MaterialModelWriterVisitorProtocol
 
 try:
     import ansys.dpf.core as dpf
@@ -138,7 +138,7 @@ class MaterialModel(BaseModel, abc.ABC):
         """
         return cls(**value)
 
-    def accept(self, visitor: MaterialModelWriterVisitor, *, material_name: str) -> Any:
+    def accept(self, visitor: MaterialModelWriterVisitorProtocol, *, material_name: str) -> Any:
         """Dispatch this model to a writer visitor.
 
         Calls ``visitor.visit(self, material_name=material_name)``. The
@@ -147,7 +147,7 @@ class MaterialModel(BaseModel, abc.ABC):
 
         Parameters
         ----------
-        visitor : MaterialModelWriterVisitor
+        visitor : MaterialModelWriterVisitorProtocol
             A writer instance (e.g. ``MatmlWriter``, ``MapdlWriter``).
         material_name : str
             Name of the parent :class:`~ansys.materials.manager.models.Material`,

--- a/src/ansys/materials/manager/models/_common/material_model.py
+++ b/src/ansys/materials/manager/models/_common/material_model.py
@@ -23,6 +23,7 @@
 import abc
 import functools
 import re
+from typing import Any
 
 from ansys.units import Quantity
 import numpy as np
@@ -34,6 +35,7 @@ from .independent_parameter import IndependentParameter
 from .interpolation_options import InterpolationOptions
 from .model_qualifier import ModelQualifier
 from .tabular_quantity import TabularQuantity
+from .visitor_protocol import MaterialModelWriterVisitor
 
 try:
     import ansys.dpf.core as dpf
@@ -135,6 +137,28 @@ class MaterialModel(BaseModel, abc.ABC):
             Dictionary containing the material model data. If `None`, returns `None`.
         """
         return cls(**value)
+
+    def accept(self, visitor: MaterialModelWriterVisitor, *, material_name: str) -> Any:
+        """Dispatch this model to a writer visitor.
+
+        Calls ``visitor.visit(self, material_name=material_name)``. The
+        visitor selects the correct serialization logic based on the
+        concrete type of ``self`` (e.g. ``Density``, ``ElasticityIsotropic``).
+
+        Parameters
+        ----------
+        visitor : MaterialModelWriterVisitor
+            A writer instance (e.g. ``MatmlWriter``, ``MapdlWriter``).
+        material_name : str
+            Name of the parent :class:`~ansys.materials.manager.models.Material`,
+            used to group output.
+
+        Returns
+        -------
+        Any
+            Format-specific serialization result from the visitor.
+        """
+        return visitor.visit(self, material_name=material_name)
 
     def validate_model(self) -> None:
         """

--- a/src/ansys/materials/manager/models/_common/visitor_protocol.py
+++ b/src/ansys/materials/manager/models/_common/visitor_protocol.py
@@ -25,12 +25,26 @@
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
+    from ..material import Material
     from .material_model import MaterialModel
 
 
-class MaterialModelWriterVisitor(Protocol):
-    """Structural type for writer visitors that accept material models."""
+class MaterialModelWriterVisitorProtocol(Protocol):
+    """Structural type for writer visitors accepted by :meth:`MaterialModel.accept`.
+
+    The integrations ABC :class:`~ansys.materials.manager.integrations.MaterialModelWriterVisitor`
+    implements this protocol. ``models`` imports only this protocol so the domain
+    layer never depends on ``integrations``.
+    """
 
     def visit(self, model: "MaterialModel", *, material_name: str) -> Any:
         """Serialize a material model for the parent material name."""
+        ...
+
+    def visit_material(self, material: "Material") -> None:
+        """Visit every supported model on a material."""
+        ...
+
+    def is_supported(self, material_model: "MaterialModel") -> bool:
+        """Return whether this writer supports the given model type."""
         ...

--- a/src/ansys/materials/manager/models/_common/visitor_protocol.py
+++ b/src/ansys/materials/manager/models/_common/visitor_protocol.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Typing protocol for material model writer visitors (avoids importing integrations)."""
+
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from .material_model import MaterialModel
+
+
+class MaterialModelWriterVisitor(Protocol):
+    """Structural type for writer visitors that accept material models."""
+
+    def visit(self, model: "MaterialModel", *, material_name: str) -> Any:
+        """Serialize a material model for the parent material name."""
+        ...

--- a/src/ansys/materials/manager/models/material.py
+++ b/src/ansys/materials/manager/models/material.py
@@ -25,6 +25,7 @@ from typing import List
 import uuid
 
 from ._common import MaterialModel
+from ._common.visitor_protocol import MaterialModelWriterVisitor
 
 
 class Material:
@@ -131,3 +132,18 @@ class Material:
         model = self.get_model_by_name(model_name)
         if model is not None:
             self._models.remove(model)
+
+    def accept(self, visitor: MaterialModelWriterVisitor) -> None:
+        """Visit every model on this material with a writer visitor.
+
+        Iterates :attr:`models` and calls :meth:`MaterialModel.accept` for each,
+        passing ``material_name=self.name``. This is the typical entry point
+        when a writer traverses a :class:`Material`.
+
+        Parameters
+        ----------
+        visitor : MaterialModelWriterVisitor
+            Writer instance (must implement :meth:`~MaterialModelWriterVisitor.visit_material`
+            or be a :class:`~ansys.materials.manager.integrations.BaseVisitor` subclass).
+        """
+        visitor.visit_material(self)

--- a/src/ansys/materials/manager/models/material.py
+++ b/src/ansys/materials/manager/models/material.py
@@ -25,7 +25,7 @@ from typing import List
 import uuid
 
 from ._common import MaterialModel
-from ._common.visitor_protocol import MaterialModelWriterVisitor
+from ._common.visitor_protocol import MaterialModelWriterVisitorProtocol
 
 
 class Material:
@@ -133,7 +133,7 @@ class Material:
         if model is not None:
             self._models.remove(model)
 
-    def accept(self, visitor: MaterialModelWriterVisitor) -> None:
+    def accept(self, visitor: MaterialModelWriterVisitorProtocol) -> None:
         """Visit every model on this material with a writer visitor.
 
         Iterates :attr:`models` and calls :meth:`MaterialModel.accept` for each,
@@ -142,8 +142,7 @@ class Material:
 
         Parameters
         ----------
-        visitor : MaterialModelWriterVisitor
-            Writer instance (must implement :meth:`~MaterialModelWriterVisitor.visit_material`
-            or be a :class:`~ansys.materials.manager.integrations.BaseVisitor` subclass).
+        visitor : MaterialModelWriterVisitorProtocol
+            Writer instance (e.g. ``MatmlWriter``, ``MapdlWriter``).
         """
         visitor.visit_material(self)

--- a/tests/integrations/__init__.py
+++ b/tests/integrations/__init__.py
@@ -1,1 +1,23 @@
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 # Integration visitor tests package.

--- a/tests/integrations/__init__.py
+++ b/tests/integrations/__init__.py
@@ -1,0 +1,1 @@
+# Integration visitor tests package.

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -1,0 +1,77 @@
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Shared fixtures for integration visitor tests."""
+
+from functools import singledispatchmethod
+
+import pytest
+from ansys.units import Quantity
+
+from ansys.materials.manager.integrations._common import ModelInfo
+from ansys.materials.manager.integrations.base_visitor import BaseVisitor
+from ansys.materials.manager.models import Density, ElasticityIsotropic, Material, MaterialModel
+
+
+class RecordingVisitor(BaseVisitor):
+    """Minimal visitor that records (type, material_name) pairs for dispatch tests."""
+
+    def __init__(self, materials: list[Material], model_map: dict | None = None):
+        if model_map is None:
+            model_map = {Density: ModelInfo()}
+        super().__init__(materials, model_map=model_map)
+        self.recorded: list[tuple[type, str]] = []
+
+    @singledispatchmethod
+    def visit(self, model: MaterialModel, *, material_name: str) -> None:
+        self.recorded.append((type(model), material_name))
+
+    @visit.register(ElasticityIsotropic)
+    def _visit_elasticity(self, model: ElasticityIsotropic, *, material_name: str) -> None:
+        self.recorded.append((ElasticityIsotropic, material_name))
+
+
+@pytest.fixture
+def material_with():
+    """Factory fixture for building materials with a single model."""
+
+    def _factory(model: MaterialModel, name: str = "test", material_id: int = 1) -> Material:
+        return Material(name=name, material_id=material_id, models=[model])
+
+    return _factory
+
+
+@pytest.fixture
+def minimal_model_factory():
+    """Build minimal valid instances for map-coverage smoke tests."""
+
+    def _factory(model_cls: type[MaterialModel]) -> MaterialModel | None:
+        if model_cls is Density:
+            return Density(density=Quantity(value=[1.0], units="kg m^-3"))
+        if model_cls is ElasticityIsotropic:
+            return ElasticityIsotropic(
+                youngs_modulus=Quantity(value=[2.0e11], units="Pa"),
+                poissons_ratio=Quantity(value=[0.3], units=""),
+            )
+        return None
+
+    return _factory

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -24,8 +24,8 @@
 
 from functools import singledispatchmethod
 
-import pytest
 from ansys.units import Quantity
+import pytest
 
 from ansys.materials.manager.integrations._common import ModelInfo
 from ansys.materials.manager.integrations.base_visitor import BaseVisitor

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -29,6 +29,9 @@ import pytest
 
 from ansys.materials.manager.integrations._common import ModelInfo
 from ansys.materials.manager.integrations.base_visitor import BaseVisitor
+from ansys.materials.manager.integrations.material_model_writer_visitor import (
+    UnsupportedMaterialModelError,
+)
 from ansys.materials.manager.models import Density, ElasticityIsotropic, Material, MaterialModel
 
 
@@ -43,6 +46,12 @@ class RecordingVisitor(BaseVisitor):
 
     @singledispatchmethod
     def visit(self, model: MaterialModel, *, material_name: str) -> None:
+        raise UnsupportedMaterialModelError(
+            f"{type(self).__name__} has no visit handler for {model.__class__.__name__}"
+        )
+
+    @visit.register(MaterialModel)
+    def _visit_model(self, model: MaterialModel, *, material_name: str) -> None:
         self.recorded.append((type(model), material_name))
 
     @visit.register(ElasticityIsotropic)

--- a/tests/integrations/test_visitor_dispatch.py
+++ b/tests/integrations/test_visitor_dispatch.py
@@ -1,0 +1,118 @@
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import warnings
+
+import pytest
+from ansys.units import Quantity
+
+from ansys.materials.manager.integrations._common import ModelInfo
+from ansys.materials.manager.integrations.base_visitor import BaseVisitor
+from ansys.materials.manager.integrations.material_model_writer_visitor import (
+    UnsupportedMaterialModelError,
+)
+from ansys.materials.manager.models import Density, ElasticityIsotropic, Material, MaterialModel
+
+from .conftest import RecordingVisitor
+
+
+def test_material_model_accept_delegates_to_visit():
+    """MaterialModel.accept should call visitor.visit with material_name."""
+    density = Density(density=Quantity(value=[1.0], units="kg m^-3"))
+    material = Material(name="steel", models=[density])
+    visitor = RecordingVisitor([material], model_map={Density: ModelInfo()})
+
+    density.accept(visitor, material_name="steel")
+
+    assert visitor.recorded == [(Density, "steel")]
+
+
+def test_material_accept_visits_all_models_in_order():
+    """Material.accept should visit each child model."""
+    density = Density(density=Quantity(value=[1.0], units="kg m^-3"))
+    elasticity = ElasticityIsotropic(
+        youngs_modulus=Quantity(value=[2.0e11], units="Pa"),
+        poissons_ratio=Quantity(value=[0.3], units=""),
+    )
+    material = Material(name="alloy", models=[density, elasticity])
+    visitor = RecordingVisitor(
+        [material],
+        model_map={Density: ModelInfo(), ElasticityIsotropic: ModelInfo()},
+    )
+
+    material.accept(visitor)
+
+    assert visitor.recorded == [(Density, "alloy"), (ElasticityIsotropic, "alloy")]
+
+
+def test_singledispatch_picks_specific_handler():
+    """visit.register should dispatch by concrete model type."""
+    elasticity = ElasticityIsotropic(
+        youngs_modulus=Quantity(value=[2.0e11], units="Pa"),
+        poissons_ratio=Quantity(value=[0.3], units=""),
+    )
+    material = Material(name="m", models=[elasticity])
+    visitor = RecordingVisitor([material], model_map={ElasticityIsotropic: ModelInfo()})
+
+    elasticity.accept(visitor, material_name="m")
+
+    assert visitor.recorded == [(ElasticityIsotropic, "m")]
+
+
+def test_unsupported_model_skipped_during_visit_material(capsys):
+    """Unsupported models should be skipped with a message, not raise."""
+    density = Density(density=Quantity(value=[1.0], units="kg m^-3"))
+    material = Material(name="m", models=[density])
+    visitor = RecordingVisitor([material], model_map={})
+
+    material.accept(visitor)
+
+    captured = capsys.readouterr()
+    assert "Density" in captured.out
+    assert visitor.recorded == []
+
+
+def test_visit_material_model_deprecated_shim(capsys):
+    """visit_material_model should warn and delegate to accept."""
+
+    class StubWriter(BaseVisitor):
+        def visit(self, model: MaterialModel, *, material_name: str) -> None:
+            pass
+
+    density = Density(density=Quantity(value=[1.0], units="kg m^-3"))
+    material = Material(name="m", models=[density])
+    writer = StubWriter([material], model_map={Density: ModelInfo()})
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        writer.visit_material_model("m", density)
+
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_base_visitor_visit_raises_without_handler():
+    """BaseVisitor.visit should raise when no handler is defined."""
+    density = Density(density=Quantity(value=[1.0], units="kg m^-3"))
+    writer = BaseVisitor([Material(name="m", models=[density])], model_map={Density: ModelInfo()})
+
+    with pytest.raises(UnsupportedMaterialModelError):
+        density.accept(writer, material_name="m")

--- a/tests/integrations/test_visitor_dispatch.py
+++ b/tests/integrations/test_visitor_dispatch.py
@@ -20,6 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from functools import singledispatchmethod
 import logging
 import warnings
 
@@ -103,6 +104,29 @@ def test_is_supported_requires_model_map_and_visit_handler():
         model_map={Density: ModelInfo()},
     )
     assert visitor.is_supported(density) is True
+
+
+def test_is_supported_false_when_singledispatch_has_no_concrete_handlers():
+    """is_supported ignores the default object entry in singledispatch registries."""
+
+    class StubWriter(BaseVisitor):
+        @singledispatchmethod
+        def visit(self, model: MaterialModel, *, material_name: str) -> None:
+            raise UnsupportedMaterialModelError("no handler")
+
+    density = Density(density=Quantity(value=[1.0], units="kg m^-3"))
+    writer = StubWriter([Material(name="m", models=[density])], model_map={Density: ModelInfo()})
+    assert writer.is_supported(density) is False
+
+
+def test_populate_dependent_parameters_skips_partial_model_info():
+    """Partial ModelInfo rows without both labels and attributes return no output."""
+    density = Density(density=Quantity(value=[1.0], units="kg m^-3"))
+    writer = BaseVisitor(
+        [Material(name="m", models=[density])],
+        model_map={Density: ModelInfo(attributes=["density"])},
+    )
+    assert writer._populate_dependent_parameters(density) == {}
 
 
 def test_visit_material_model_deprecated_shim(capsys):

--- a/tests/integrations/test_visitor_dispatch.py
+++ b/tests/integrations/test_visitor_dispatch.py
@@ -20,10 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import logging
 import warnings
 
-import pytest
 from ansys.units import Quantity
+import pytest
 
 from ansys.materials.manager.integrations._common import ModelInfo
 from ansys.materials.manager.integrations.base_visitor import BaseVisitor
@@ -78,17 +79,30 @@ def test_singledispatch_picks_specific_handler():
     assert visitor.recorded == [(ElasticityIsotropic, "m")]
 
 
-def test_unsupported_model_skipped_during_visit_material(capsys):
-    """Unsupported models should be skipped with a message, not raise."""
+def test_unsupported_model_skipped_during_visit_material(caplog):
+    """Unsupported models should be skipped with a warning, not raise."""
     density = Density(density=Quantity(value=[1.0], units="kg m^-3"))
     material = Material(name="m", models=[density])
     visitor = RecordingVisitor([material], model_map={})
 
-    material.accept(visitor)
+    with caplog.at_level(logging.WARNING):
+        material.accept(visitor)
 
-    captured = capsys.readouterr()
-    assert "Density" in captured.out
+    assert "Density" in caplog.text
     assert visitor.recorded == []
+
+
+def test_is_supported_requires_model_map_and_visit_handler():
+    """is_supported is False when the map or visit handler is missing."""
+    density = Density(density=Quantity(value=[1.0], units="kg m^-3"))
+    writer = BaseVisitor([Material(name="m", models=[density])], model_map={Density: ModelInfo()})
+    assert writer.is_supported(density) is False
+
+    visitor = RecordingVisitor(
+        [Material(name="m", models=[density])],
+        model_map={Density: ModelInfo()},
+    )
+    assert visitor.is_supported(density) is True
 
 
 def test_visit_material_model_deprecated_shim(capsys):

--- a/tests/integrations/test_writer_map_coverage.py
+++ b/tests/integrations/test_writer_map_coverage.py
@@ -52,14 +52,18 @@ from ansys.materials.manager.models import Material
 )
 def test_mapped_models_accept_without_error(writer_cls, model_map, minimal_model_factory):
     """Each mapped model type should traverse via accept without raising."""
+    tested = 0
     for model_cls in model_map:
         model = minimal_model_factory(model_cls)
         if model is None:
-            pytest.skip(f"No minimal fixture for {model_cls.__name__} yet")
+            continue
 
+        tested += 1
         material = Material(name="test", material_id=1, models=[model])
         writer = writer_cls([material])
         assert material.name in writer._material_repr
+
+    assert tested > 0, f"No minimal fixtures available for {writer_cls.__name__}"
 
 
 @pytest.mark.parametrize(

--- a/tests/integrations/test_writer_map_coverage.py
+++ b/tests/integrations/test_writer_map_coverage.py
@@ -1,0 +1,81 @@
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+
+from ansys.materials.manager.integrations.fluent._fluent_model_map import (
+    MATERIAL_MODEL_MAP as FLUENT_MAP,
+)
+from ansys.materials.manager.integrations.fluent.fluent_writer import FluentWriter
+from ansys.materials.manager.integrations.lsdyna._ls_dyna_model_map import (
+    MATERIAL_MODEL_MAP as LSDYNA_MAP,
+)
+from ansys.materials.manager.integrations.lsdyna.lsdyna_writer import LsDynaWriter
+from ansys.materials.manager.integrations.mapdl._mapdl_model_map import (
+    MATERIAL_MODEL_MAP as MAPDL_MAP,
+)
+from ansys.materials.manager.integrations.mapdl.mapdl_writer import MapdlWriter
+from ansys.materials.manager.integrations.matml._matml_model_map import (
+    MATERIAL_MODEL_MAP as MATML_MAP,
+)
+from ansys.materials.manager.integrations.matml.matml_writer import MatmlWriter
+from ansys.materials.manager.models import Material
+
+
+@pytest.mark.parametrize(
+    "writer_cls,model_map",
+    [
+        (MatmlWriter, MATML_MAP),
+        (MapdlWriter, MAPDL_MAP),
+        (FluentWriter, FLUENT_MAP),
+        (LsDynaWriter, LSDYNA_MAP),
+    ],
+)
+def test_mapped_models_accept_without_error(writer_cls, model_map, minimal_model_factory):
+    """Each mapped model type should traverse via accept without raising."""
+    for model_cls in model_map:
+        model = minimal_model_factory(model_cls)
+        if model is None:
+            pytest.skip(f"No minimal fixture for {model_cls.__name__} yet")
+
+        material = Material(name="test", material_id=1, models=[model])
+        writer = writer_cls([material])
+        assert material.name in writer._material_repr
+
+
+@pytest.mark.parametrize(
+    "model_map",
+    [MATML_MAP, MAPDL_MAP, FLUENT_MAP, LSDYNA_MAP],
+)
+def test_model_info_label_attribute_alignment(model_map):
+    """ModelInfo entries should have aligned labels and attributes when both are set."""
+    for model_cls, info in model_map.items():
+        if info.method_write or info.method_read:
+            continue
+        if not info.labels or not info.attributes:
+            continue
+        flat_labels = info.labels
+        if flat_labels and isinstance(flat_labels[0], list):
+            flat_labels = [label for group in flat_labels for label in group]
+        assert len(flat_labels) == len(info.attributes), model_cls.__name__
+        for attribute in info.attributes:
+            assert hasattr(model_cls, "model_fields") or hasattr(model_cls, attribute)


### PR DESCRIPTION
## Summary

- Introduce double-dispatch traversal (`Material.accept` / `MaterialModel.accept`) so format writers visit domain models without `isinstance` chains or importing solver logic into `models`.
- Migrate MatML, MAPDL, Fluent, and LS-DYNA writers to per-class `@singledispatchmethod visit` handlers with explicit `model_map` registration (replacing the `sys.modules` map hack).
- Add integration tests, a contributor developer guide, and follow-up fixes for protocol naming (`MaterialModelWriterVisitorProtocol`), `is_supported` alignment with visit handlers, and logging warnings when unsupported models are skipped.

Closes #416

## Test plan

- [x] `pytest tests/integrations/` — visitor dispatch, `is_supported`, and writer map coverage smoke tests
- [ ] `pytest tests/matml/ tests/mapdl/ tests/fluent/ tests/lsdyna/` — existing golden-file writer tests
- [ ] Sphinx docs build (`doc/source/developer_guide.rst`)
